### PR TITLE
[codex] fix duel state, live standings, and fantasy pricing aliases

### DIFF
--- a/data/mini_fantasy_prices.json
+++ b/data/mini_fantasy_prices.json
@@ -17,9 +17,9 @@
   "summary": {
     "total_players_received": 250,
     "eligible_players_ranked": 250,
-    "price_rises": 0,
+    "price_rises": 12,
     "price_drops": 1,
-    "price_unchanged": 249
+    "price_unchanged": 237
   },
   "players": [
     {
@@ -42,10 +42,9 @@
       "score_basis": 41,
       "reliability_factor": 0.75,
       "adjusted_score": 30.75,
-      "percentile": 93.17,
+      "percentile": 91.97,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Uncapped player price ceiling applied at 9 credits"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
     },
@@ -69,7 +68,7 @@
       "score_basis": 33,
       "reliability_factor": 0.75,
       "adjusted_score": 24.75,
-      "percentile": 87.55,
+      "percentile": 84.74,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -88,17 +87,17 @@
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
-      "matches_played": 3,
-      "season_avg_points": 47,
-      "recent_avg_points": 47,
+      "matches_played": 5,
+      "season_avg_points": 31.6,
+      "recent_avg_points": 42.33,
       "last_match_points": 64,
-      "score_basis": 47,
-      "reliability_factor": 0.75,
-      "adjusted_score": 35.25,
-      "percentile": 95.78,
+      "score_basis": 38.04,
+      "reliability_factor": 1,
+      "adjusted_score": 38.04,
+      "percentile": 96.99,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 95.78",
+        "Target price mapped from percentile 96.99",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -123,7 +122,7 @@
       "score_basis": 34.33,
       "reliability_factor": 0.75,
       "adjusted_score": 25.75,
-      "percentile": 88.76,
+      "percentile": 85.94,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -149,10 +148,10 @@
       "score_basis": 54,
       "reliability_factor": 0.5,
       "adjusted_score": 27,
-      "percentile": 90.36,
+      "percentile": 87.55,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 90.36",
+        "Target price mapped from percentile 87.55",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -177,7 +176,7 @@
       "score_basis": 16.67,
       "reliability_factor": 0.75,
       "adjusted_score": 12.5,
-      "percentile": 73.29,
+      "percentile": 67.67,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -192,7 +191,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -203,9 +202,11 @@
       "score_basis": 14.33,
       "reliability_factor": 0.75,
       "adjusted_score": 10.75,
-      "percentile": 69.48,
+      "percentile": 64.26,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 64.26",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
     },
@@ -218,7 +219,7 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
@@ -229,39 +230,9 @@
       "score_basis": 9.67,
       "reliability_factor": 0.75,
       "adjusted_score": 7.25,
-      "percentile": 65.46,
+      "percentile": 58.23,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 65.46",
-        "Applied smoothing against the target price"
-      ],
-      "last_match_played_at_utc": "2026-04-05T14:00:00Z"
-    },
-    {
-      "player_id": "csk_khaleel-ahmed",
-      "name": "Khaleel Ahmed",
-      "team": "CSK",
-      "role": "bowler",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 7,
-      "initial_price": 7,
-      "target_price": 6,
-      "smoothed_price": 7,
-      "final_price": 7,
-      "price_change": 0,
-      "matches_played": 3,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": -2,
-      "score_basis": 0,
-      "reliability_factor": 0.75,
-      "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 26.31",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
     },
@@ -285,7 +256,7 @@
       "score_basis": 7.33,
       "reliability_factor": 0.75,
       "adjusted_score": 5.5,
-      "percentile": 60.64,
+      "percentile": 53.82,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -311,10 +282,10 @@
       "score_basis": 26.5,
       "reliability_factor": 0.5,
       "adjusted_score": 13.25,
-      "percentile": 74.3,
+      "percentile": 68.27,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 74.3",
+        "Target price mapped from percentile 68.27",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -339,7 +310,7 @@
       "score_basis": 3,
       "reliability_factor": 0.25,
       "adjusted_score": 0.75,
-      "percentile": 53.21,
+      "percentile": 45.98,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -365,7 +336,7 @@
       "score_basis": 8,
       "reliability_factor": 0.75,
       "adjusted_score": 6,
-      "percentile": 61.85,
+      "percentile": 54.62,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -380,7 +351,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -391,7 +362,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -407,23 +378,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 1,
+      "season_avg_points": 40,
+      "recent_avg_points": 40,
+      "last_match_points": 40,
+      "score_basis": 40,
+      "reliability_factor": 0.25,
+      "adjusted_score": 10,
+      "percentile": 62.85,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 62.85",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
     {
       "player_id": "csk_dewald-brevis",
@@ -434,7 +406,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -445,7 +417,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -461,7 +433,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -472,12 +444,40 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
       ],
       "last_match_played_at_utc": null
+    },
+    {
+      "player_id": "csk_khaleel-ahmed",
+      "name": "Khaleel Ahmed",
+      "team": "CSK",
+      "role": "bowler",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 7,
+      "initial_price": 7,
+      "target_price": 5,
+      "smoothed_price": 6,
+      "final_price": 6,
+      "price_change": -1,
+      "matches_played": 3,
+      "season_avg_points": 0,
+      "recent_avg_points": 0,
+      "last_match_points": -2,
+      "score_basis": 0,
+      "reliability_factor": 0.75,
+      "adjusted_score": 0,
+      "percentile": 22.49,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 22.49",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-05T14:00:00Z"
     },
     {
       "player_id": "csk_matthew-william-short",
@@ -488,23 +488,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 1,
+      "season_avg_points": 2,
+      "recent_avg_points": 2,
+      "last_match_points": 2,
+      "score_basis": 2,
+      "reliability_factor": 0.25,
+      "adjusted_score": 0.5,
+      "percentile": 45.38,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 45.38",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-03-30T14:00:00Z"
     },
     {
       "player_id": "csk_ms-dhoni",
@@ -515,7 +516,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -526,7 +527,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -542,23 +543,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 2,
+      "season_avg_points": 8,
+      "recent_avg_points": 8,
+      "last_match_points": 2,
+      "score_basis": 8,
+      "reliability_factor": 0.5,
+      "adjusted_score": 4,
+      "percentile": 51.41,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 51.41",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
     {
       "player_id": "csk_ramakrishna-ghosh",
@@ -569,7 +571,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -580,7 +582,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -596,7 +598,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -607,7 +609,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -623,7 +625,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -634,7 +636,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -650,7 +652,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -661,7 +663,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -677,7 +679,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -688,7 +690,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -715,10 +717,10 @@
       "score_basis": 29,
       "reliability_factor": 0.5,
       "adjusted_score": 14.5,
-      "percentile": 77.11,
+      "percentile": 71.08,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 77.11",
+        "Target price mapped from percentile 71.08",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
@@ -770,7 +772,7 @@
       "score_basis": 47,
       "reliability_factor": 0.5,
       "adjusted_score": 23.5,
-      "percentile": 86.35,
+      "percentile": 81.73,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -796,10 +798,10 @@
       "score_basis": 34,
       "reliability_factor": 0.5,
       "adjusted_score": 17,
-      "percentile": 78.71,
+      "percentile": 72.69,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 78.71",
+        "Target price mapped from percentile 72.69",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
@@ -824,7 +826,7 @@
       "score_basis": 28,
       "reliability_factor": 0.5,
       "adjusted_score": 14,
-      "percentile": 76.1,
+      "percentile": 70.08,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -850,10 +852,10 @@
       "score_basis": 14.5,
       "reliability_factor": 0.5,
       "adjusted_score": 7.25,
-      "percentile": 64.86,
+      "percentile": 57.63,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.86",
+        "Target price mapped from percentile 57.63",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
@@ -878,7 +880,7 @@
       "score_basis": 24,
       "reliability_factor": 0.5,
       "adjusted_score": 12,
-      "percentile": 71.69,
+      "percentile": 66.27,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -904,11 +906,39 @@
       "score_basis": 23.5,
       "reliability_factor": 0.5,
       "adjusted_score": 11.75,
-      "percentile": 70.68,
+      "percentile": 65.46,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
+    },
+    {
+      "player_id": "dc_ashutosh-sharma",
+      "name": "Ashutosh Sharma",
+      "team": "DC",
+      "role": "all_rounder",
+      "is_uncapped": true,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 9,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 5,
+      "season_avg_points": 24.5,
+      "recent_avg_points": 29.67,
+      "last_match_points": 0,
+      "score_basis": 27.6,
+      "reliability_factor": 1,
+      "adjusted_score": 27.6,
+      "percentile": 89.16,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 89.16",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
     {
       "player_id": "dc_kl-rahul",
@@ -930,9 +960,37 @@
       "score_basis": 4.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.25,
-      "percentile": 55.82,
+      "percentile": 48.59,
       "calculation_notes": [
         "Used old_price for smoothing"
+      ],
+      "last_match_played_at_utc": "2026-04-04T10:00:00Z"
+    },
+    {
+      "player_id": "dc_lungisani-ngidi",
+      "name": "Lungisani Ngidi",
+      "team": "DC",
+      "role": "bowler",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 9,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 2,
+      "season_avg_points": 47,
+      "recent_avg_points": 47,
+      "last_match_points": 20,
+      "score_basis": 47,
+      "reliability_factor": 0.5,
+      "adjusted_score": 23.5,
+      "percentile": 81.73,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 81.73",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
     },
@@ -956,7 +1014,7 @@
       "score_basis": 12.5,
       "reliability_factor": 0.5,
       "adjusted_score": 6.25,
-      "percentile": 62.45,
+      "percentile": 55.22,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -982,7 +1040,7 @@
       "score_basis": 10,
       "reliability_factor": 0.5,
       "adjusted_score": 5,
-      "percentile": 60.24,
+      "percentile": 53.41,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -997,7 +1055,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1008,7 +1066,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1024,7 +1082,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1035,34 +1093,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "dc_ashutosh-sharma",
-      "name": "Ashutosh Sharma",
-      "team": "DC",
-      "role": "all_rounder",
-      "is_uncapped": true,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1078,7 +1109,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1089,7 +1120,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1105,7 +1136,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1116,7 +1147,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1132,7 +1163,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1143,7 +1174,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1159,7 +1190,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1170,7 +1201,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1186,7 +1217,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1197,34 +1228,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "dc_lungisani-ngidi",
-      "name": "Lungisani Ngidi",
-      "team": "DC",
-      "role": "bowler",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1240,7 +1244,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1251,7 +1255,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1267,7 +1271,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1278,7 +1282,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1294,7 +1298,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1305,7 +1309,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1321,7 +1325,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1332,7 +1336,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1348,7 +1352,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1359,7 +1363,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1386,10 +1390,10 @@
       "score_basis": 53.5,
       "reliability_factor": 0.5,
       "adjusted_score": 26.75,
-      "percentile": 89.76,
+      "percentile": 86.95,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 89.76",
+        "Target price mapped from percentile 86.95",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T14:00:00Z"
@@ -1403,7 +1407,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -1414,9 +1418,11 @@
       "score_basis": 43,
       "reliability_factor": 0.5,
       "adjusted_score": 21.5,
-      "percentile": 84.74,
+      "percentile": 79.52,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 79.52",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T14:00:00Z"
     },
@@ -1429,7 +1435,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -1440,9 +1446,11 @@
       "score_basis": 41,
       "reliability_factor": 0.5,
       "adjusted_score": 20.5,
-      "percentile": 84.34,
+      "percentile": 79.12,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 79.12",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T14:00:00Z"
     },
@@ -1466,7 +1474,7 @@
       "score_basis": 50,
       "reliability_factor": 0.5,
       "adjusted_score": 25,
-      "percentile": 87.95,
+      "percentile": 85.14,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1481,7 +1489,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -1492,9 +1500,11 @@
       "score_basis": 36,
       "reliability_factor": 0.5,
       "adjusted_score": 18,
-      "percentile": 80.52,
+      "percentile": 74.5,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 74.5",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T14:00:00Z"
     },
@@ -1518,10 +1528,10 @@
       "score_basis": 57,
       "reliability_factor": 0.25,
       "adjusted_score": 14.25,
-      "percentile": 76.71,
+      "percentile": 70.68,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 76.71",
+        "Target price mapped from percentile 70.68",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-03-31T14:00:00Z"
@@ -1535,22 +1545,24 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 9,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 2,
-      "season_avg_points": 24,
-      "recent_avg_points": 24,
-      "last_match_points": 25,
-      "score_basis": 24,
-      "reliability_factor": 0.5,
-      "adjusted_score": 12,
-      "percentile": 71.69,
+      "matches_played": 5,
+      "season_avg_points": 24.5,
+      "recent_avg_points": 29.67,
+      "last_match_points": 0,
+      "score_basis": 27.6,
+      "reliability_factor": 1,
+      "adjusted_score": 27.6,
+      "percentile": 89.16,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 89.16",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": "2026-04-04T14:00:00Z"
+      "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
     {
       "player_id": "gt_glenn-phillips",
@@ -1572,7 +1584,7 @@
       "score_basis": 23,
       "reliability_factor": 0.5,
       "adjusted_score": 11.5,
-      "percentile": 70.28,
+      "percentile": 65.06,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1598,13 +1610,42 @@
       "score_basis": 26,
       "reliability_factor": 0.25,
       "adjusted_score": 6.5,
-      "percentile": 63.25,
+      "percentile": 56.02,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 63.25",
+        "Target price mapped from percentile 56.02",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T14:00:00Z"
+    },
+    {
+      "player_id": "gt_shahrukh-khan",
+      "name": "Shahrukh Khan",
+      "team": "GT",
+      "role": "batter",
+      "is_uncapped": true,
+      "pricing_eligible": true,
+      "old_price": 7,
+      "initial_price": 7,
+      "target_price": 9,
+      "smoothed_price": 8,
+      "final_price": 8,
+      "price_change": 1,
+      "matches_played": 5,
+      "season_avg_points": 31.6,
+      "recent_avg_points": 42.33,
+      "last_match_points": 64,
+      "score_basis": 38.04,
+      "reliability_factor": 1,
+      "adjusted_score": 38.04,
+      "percentile": 96.99,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 96.99",
+        "Applied smoothing against the target price",
+        "Uncapped player price ceiling applied at 9 credits"
+      ],
+      "last_match_played_at_utc": "2026-04-05T14:00:00Z"
     },
     {
       "player_id": "gt_washington-sundar",
@@ -1626,7 +1667,7 @@
       "score_basis": 25,
       "reliability_factor": 0.5,
       "adjusted_score": 12.5,
-      "percentile": 72.69,
+      "percentile": 67.07,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1652,7 +1693,7 @@
       "score_basis": 11.5,
       "reliability_factor": 0.5,
       "adjusted_score": 5.75,
-      "percentile": 61.45,
+      "percentile": 54.22,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1678,33 +1719,7 @@
       "score_basis": 12.5,
       "reliability_factor": 0.5,
       "adjusted_score": 6.25,
-      "percentile": 62.45,
-      "calculation_notes": [
-        "Used old_price for smoothing"
-      ],
-      "last_match_played_at_utc": "2026-04-04T14:00:00Z"
-    },
-    {
-      "player_id": "gt_shahrukh-khan",
-      "name": "Shahrukh Khan",
-      "team": "GT",
-      "role": "batter",
-      "is_uncapped": true,
-      "pricing_eligible": true,
-      "old_price": 7,
-      "initial_price": 7,
-      "target_price": 7,
-      "smoothed_price": 7,
-      "final_price": 7,
-      "price_change": 0,
-      "matches_played": 2,
-      "season_avg_points": 8.5,
-      "recent_avg_points": 8.5,
-      "last_match_points": 13,
-      "score_basis": 8.5,
-      "reliability_factor": 0.5,
-      "adjusted_score": 4.25,
-      "percentile": 59.44,
+      "percentile": 55.22,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1719,7 +1734,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1730,7 +1745,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1746,7 +1761,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1757,7 +1772,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1773,7 +1788,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1784,7 +1799,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1800,7 +1815,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1811,7 +1826,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1827,7 +1842,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1838,7 +1853,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1854,7 +1869,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1865,7 +1880,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1881,7 +1896,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1892,7 +1907,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1908,7 +1923,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1919,7 +1934,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1935,23 +1950,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 1,
+      "season_avg_points": 36,
+      "recent_avg_points": 36,
+      "last_match_points": 36,
+      "score_basis": 36,
+      "reliability_factor": 0.25,
+      "adjusted_score": 9,
+      "percentile": 60.84,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 60.84",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-01T14:00:00Z"
     },
     {
       "player_id": "gt_nishant-sindhu",
@@ -1962,7 +1978,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -1973,7 +1989,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1989,7 +2005,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2000,7 +2016,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2016,7 +2032,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2027,7 +2043,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2054,10 +2070,10 @@
       "score_basis": 37.67,
       "reliability_factor": 0.75,
       "adjusted_score": 28.25,
-      "percentile": 91.97,
+      "percentile": 90.76,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 91.97",
+        "Target price mapped from percentile 90.76",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-06T14:00:00Z"
@@ -2082,10 +2098,10 @@
       "score_basis": 53.5,
       "reliability_factor": 0.5,
       "adjusted_score": 26.75,
-      "percentile": 89.76,
+      "percentile": 86.95,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 89.76",
+        "Target price mapped from percentile 86.95",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T14:00:00Z"
@@ -2110,7 +2126,7 @@
       "score_basis": 47.67,
       "reliability_factor": 0.75,
       "adjusted_score": 35.75,
-      "percentile": 96.79,
+      "percentile": 95.58,
       "calculation_notes": [
         "Used old_price for smoothing",
         "Uncapped player price ceiling applied at 9 credits"
@@ -2126,7 +2142,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -2137,9 +2153,11 @@
       "score_basis": 29,
       "reliability_factor": 0.75,
       "adjusted_score": 21.75,
-      "percentile": 85.14,
+      "percentile": 79.92,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 79.92",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-06T14:00:00Z"
     },
@@ -2163,7 +2181,7 @@
       "score_basis": 48,
       "reliability_factor": 0.5,
       "adjusted_score": 24,
-      "percentile": 86.75,
+      "percentile": 83.53,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2189,10 +2207,10 @@
       "score_basis": 14,
       "reliability_factor": 0.5,
       "adjusted_score": 7,
-      "percentile": 64.06,
+      "percentile": 56.83,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.06",
+        "Target price mapped from percentile 56.83",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T14:00:00Z"
@@ -2206,7 +2224,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -2217,9 +2235,11 @@
       "score_basis": 11.33,
       "reliability_factor": 0.75,
       "adjusted_score": 8.5,
-      "percentile": 66.67,
+      "percentile": 59.84,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 59.84",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-06T14:00:00Z"
     },
@@ -2232,7 +2252,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -2243,9 +2263,39 @@
       "score_basis": 20,
       "reliability_factor": 0.5,
       "adjusted_score": 10,
-      "percentile": 68.67,
+      "percentile": 62.85,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 62.85",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-02T14:00:00Z"
+    },
+    {
+      "player_id": "kkr_ramandeep-singh",
+      "name": "Ramandeep Singh",
+      "team": "KKR",
+      "role": "all_rounder",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 7,
+      "initial_price": 7,
+      "target_price": 9,
+      "smoothed_price": 8,
+      "final_price": 8,
+      "price_change": 1,
+      "matches_played": 2,
+      "season_avg_points": 48,
+      "recent_avg_points": 48,
+      "last_match_points": 50,
+      "score_basis": 48,
+      "reliability_factor": 0.5,
+      "adjusted_score": 24,
+      "percentile": 83.53,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 83.53",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T14:00:00Z"
     },
@@ -2258,7 +2308,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -2269,9 +2319,11 @@
       "score_basis": 18,
       "reliability_factor": 0.5,
       "adjusted_score": 9,
-      "percentile": 67.27,
+      "percentile": 60.84,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 60.84",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T14:00:00Z"
     },
@@ -2295,7 +2347,7 @@
       "score_basis": 28,
       "reliability_factor": 0.5,
       "adjusted_score": 14,
-      "percentile": 76.1,
+      "percentile": 70.08,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2321,37 +2373,11 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 54.42,
+      "percentile": 47.19,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-03-29T14:00:00Z"
-    },
-    {
-      "player_id": "kkr_ramandeep-singh",
-      "name": "Ramandeep Singh",
-      "team": "KKR",
-      "role": "all_rounder",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 7,
-      "initial_price": 7,
-      "target_price": 7,
-      "smoothed_price": 7,
-      "final_price": 7,
-      "price_change": 0,
-      "matches_played": 2,
-      "season_avg_points": 11,
-      "recent_avg_points": 11,
-      "last_match_points": 18,
-      "score_basis": 11,
-      "reliability_factor": 0.5,
-      "adjusted_score": 5.5,
-      "percentile": 61.04,
-      "calculation_notes": [
-        "Used old_price for smoothing"
-      ],
-      "last_match_played_at_utc": "2026-04-02T14:00:00Z"
     },
     {
       "player_id": "kkr_varun-chakaravarthy",
@@ -2373,7 +2399,7 @@
       "score_basis": 5.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.75,
-      "percentile": 56.83,
+      "percentile": 49.6,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2388,7 +2414,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2399,7 +2425,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2415,7 +2441,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2426,7 +2452,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2442,7 +2468,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2453,7 +2479,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2469,7 +2495,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2480,7 +2506,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2496,7 +2522,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2507,7 +2533,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2523,7 +2549,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2534,7 +2560,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2550,7 +2576,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2561,7 +2587,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2577,7 +2603,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2588,7 +2614,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2604,7 +2630,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2615,7 +2641,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2631,7 +2657,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2642,7 +2668,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2658,7 +2684,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2669,7 +2695,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2685,7 +2711,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -2696,7 +2722,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2723,10 +2749,10 @@
       "score_basis": 54.5,
       "reliability_factor": 0.5,
       "adjusted_score": 27.25,
-      "percentile": 91.16,
+      "percentile": 88.35,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 91.16",
+        "Target price mapped from percentile 88.35",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
@@ -2751,10 +2777,10 @@
       "score_basis": 32,
       "reliability_factor": 0.5,
       "adjusted_score": 16,
-      "percentile": 77.91,
+      "percentile": 71.89,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 77.91",
+        "Target price mapped from percentile 71.89",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
@@ -2768,7 +2794,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -2779,9 +2805,11 @@
       "score_basis": 37.5,
       "reliability_factor": 0.5,
       "adjusted_score": 18.75,
-      "percentile": 82.33,
+      "percentile": 77.11,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 77.11",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
@@ -2805,7 +2833,7 @@
       "score_basis": 45,
       "reliability_factor": 0.5,
       "adjusted_score": 22.5,
-      "percentile": 85.54,
+      "percentile": 80.32,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2820,7 +2848,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -2831,9 +2859,11 @@
       "score_basis": 40,
       "reliability_factor": 0.25,
       "adjusted_score": 10,
-      "percentile": 68.67,
+      "percentile": 62.85,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 62.85",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
@@ -2857,7 +2887,7 @@
       "score_basis": 27.5,
       "reliability_factor": 0.5,
       "adjusted_score": 13.75,
-      "percentile": 75.3,
+      "percentile": 69.28,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2872,7 +2902,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -2883,11 +2913,41 @@
       "score_basis": 36,
       "reliability_factor": 0.25,
       "adjusted_score": 9,
-      "percentile": 67.27,
+      "percentile": 60.84,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 60.84",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-01T14:00:00Z"
+    },
+    {
+      "player_id": "lsg_akash-singh",
+      "name": "Akash Singh",
+      "team": "LSG",
+      "role": "bowler",
+      "is_uncapped": true,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 8,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 5,
+      "season_avg_points": 19.5,
+      "recent_avg_points": 17.67,
+      "last_match_points": 5,
+      "score_basis": 18.4,
+      "reliability_factor": 1,
+      "adjusted_score": 18.4,
+      "percentile": 75.5,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 75.5",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-06T14:00:00Z"
     },
     {
       "player_id": "lsg_ayush-badoni",
@@ -2909,9 +2969,37 @@
       "score_basis": 6,
       "reliability_factor": 0.5,
       "adjusted_score": 3,
-      "percentile": 57.43,
+      "percentile": 50.2,
       "calculation_notes": [
         "Used old_price for smoothing"
+      ],
+      "last_match_played_at_utc": "2026-04-05T10:00:00Z"
+    },
+    {
+      "player_id": "lsg_mohammad-shami",
+      "name": "Mohammad Shami",
+      "team": "LSG",
+      "role": "bowler",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 8,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 2,
+      "season_avg_points": 34.5,
+      "recent_avg_points": 34.5,
+      "last_match_points": 46,
+      "score_basis": 34.5,
+      "reliability_factor": 0.5,
+      "adjusted_score": 17.25,
+      "percentile": 73.09,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 73.09",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
@@ -2935,7 +3023,7 @@
       "score_basis": 8,
       "reliability_factor": 0.5,
       "adjusted_score": 4,
-      "percentile": 58.43,
+      "percentile": 51.41,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2961,38 +3049,11 @@
       "score_basis": 4.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.25,
-      "percentile": 55.82,
+      "percentile": 48.59,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
-    },
-    {
-      "player_id": "lsg_akash-singh",
-      "name": "Akash Singh",
-      "team": "LSG",
-      "role": "bowler",
-      "is_uncapped": true,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
     },
     {
       "player_id": "lsg_akshat-raghuwanshi",
@@ -3003,7 +3064,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3014,7 +3075,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3030,7 +3091,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3041,9 +3102,11 @@
       "score_basis": 0,
       "reliability_factor": 0.25,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 22.49",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-01T14:00:00Z"
     },
@@ -3056,7 +3119,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3067,7 +3130,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3083,7 +3146,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3094,7 +3157,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3110,23 +3173,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 1,
+      "season_avg_points": 15,
+      "recent_avg_points": 15,
+      "last_match_points": 15,
+      "score_basis": 15,
+      "reliability_factor": 0.25,
+      "adjusted_score": 3.75,
+      "percentile": 50.6,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 50.6",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
     {
       "player_id": "lsg_himmat-singh",
@@ -3137,7 +3201,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3148,7 +3212,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3164,7 +3228,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3175,7 +3239,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3191,23 +3255,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 1,
+      "season_avg_points": 30,
+      "recent_avg_points": 30,
+      "last_match_points": 30,
+      "score_basis": 30,
+      "reliability_factor": 0.25,
+      "adjusted_score": 7.5,
+      "percentile": 58.63,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 58.63",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
     {
       "player_id": "lsg_matthew-breetzke",
@@ -3218,7 +3283,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3229,7 +3294,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3245,7 +3310,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3256,34 +3321,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "lsg_mohammad-shami",
-      "name": "Mohammad Shami",
-      "team": "LSG",
-      "role": "bowler",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3299,7 +3337,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3310,7 +3348,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3326,7 +3364,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3337,7 +3375,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3353,7 +3391,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3364,7 +3402,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3391,7 +3429,7 @@
       "score_basis": 49,
       "reliability_factor": 0.75,
       "adjusted_score": 36.75,
-      "percentile": 97.19,
+      "percentile": 96.18,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3417,7 +3455,7 @@
       "score_basis": 46.33,
       "reliability_factor": 0.75,
       "adjusted_score": 34.75,
-      "percentile": 94.98,
+      "percentile": 94.18,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3443,7 +3481,7 @@
       "score_basis": 32.67,
       "reliability_factor": 0.75,
       "adjusted_score": 24.5,
-      "percentile": 87.15,
+      "percentile": 84.34,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3469,10 +3507,10 @@
       "score_basis": 26,
       "reliability_factor": 0.25,
       "adjusted_score": 6.5,
-      "percentile": 63.25,
+      "percentile": 56.02,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 63.25",
+        "Target price mapped from percentile 56.02",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
@@ -3497,7 +3535,7 @@
       "score_basis": 27.25,
       "reliability_factor": 0.5,
       "adjusted_score": 13.63,
-      "percentile": 74.7,
+      "percentile": 68.67,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3512,7 +3550,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -3523,9 +3561,11 @@
       "score_basis": 40,
       "reliability_factor": 0.25,
       "adjusted_score": 10,
-      "percentile": 68.67,
+      "percentile": 62.85,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 62.85",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
     },
@@ -3549,7 +3589,7 @@
       "score_basis": 22.33,
       "reliability_factor": 0.75,
       "adjusted_score": 16.75,
-      "percentile": 78.31,
+      "percentile": 72.29,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3575,7 +3615,7 @@
       "score_basis": 8.25,
       "reliability_factor": 0.5,
       "adjusted_score": 4.13,
-      "percentile": 59.04,
+      "percentile": 52.21,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3601,7 +3641,7 @@
       "score_basis": 2.5,
       "reliability_factor": 0.75,
       "adjusted_score": 1.88,
-      "percentile": 53.82,
+      "percentile": 46.59,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3627,11 +3667,68 @@
       "score_basis": 1.5,
       "reliability_factor": 0.5,
       "adjusted_score": 0.75,
-      "percentile": 53.21,
+      "percentile": 45.98,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
+    },
+    {
+      "player_id": "mi_n-tilak-varma",
+      "name": "N. Tilak Varma",
+      "team": "MI",
+      "role": "batter",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 8,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 3,
+      "season_avg_points": 25.33,
+      "recent_avg_points": 25.33,
+      "last_match_points": 32,
+      "score_basis": 25.33,
+      "reliability_factor": 0.75,
+      "adjusted_score": 19,
+      "percentile": 77.91,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 77.91",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-07T14:00:00Z"
+    },
+    {
+      "player_id": "mi_raghu-sharma",
+      "name": "Raghu Sharma",
+      "team": "MI",
+      "role": "bowler",
+      "is_uncapped": true,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 9,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 3,
+      "season_avg_points": 49,
+      "recent_avg_points": 49,
+      "last_match_points": 2,
+      "score_basis": 49,
+      "reliability_factor": 0.75,
+      "adjusted_score": 36.75,
+      "percentile": 96.18,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 96.18",
+        "Applied smoothing against the target price",
+        "Uncapped player price ceiling applied at 9 credits"
+      ],
+      "last_match_played_at_utc": "2026-04-07T14:00:00Z"
     },
     {
       "player_id": "mi_sherfane-rutherford",
@@ -3653,10 +3750,38 @@
       "score_basis": 16.67,
       "reliability_factor": 0.75,
       "adjusted_score": 12.5,
-      "percentile": 73.29,
+      "percentile": 67.67,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 73.29",
+        "Target price mapped from percentile 67.67",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-07T14:00:00Z"
+    },
+    {
+      "player_id": "mi_surya-kumar-yadav",
+      "name": "Surya Kumar Yadav",
+      "team": "MI",
+      "role": "batter",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 10,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 5,
+      "season_avg_points": 24.6,
+      "recent_avg_points": 36,
+      "last_match_points": 8,
+      "score_basis": 31.44,
+      "reliability_factor": 1,
+      "adjusted_score": 31.44,
+      "percentile": 92.37,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 92.37",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-07T14:00:00Z"
@@ -3670,23 +3795,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 2,
+      "season_avg_points": 20.5,
+      "recent_avg_points": 20.5,
+      "last_match_points": 46,
+      "score_basis": 20.5,
+      "reliability_factor": 0.5,
+      "adjusted_score": 10.25,
+      "percentile": 63.86,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 63.86",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-07T14:00:00Z"
     },
     {
       "player_id": "mi_ashwani-kumar",
@@ -3697,7 +3823,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3708,7 +3834,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3724,7 +3850,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3735,7 +3861,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3751,7 +3877,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3762,7 +3888,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3778,7 +3904,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3789,7 +3915,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3805,7 +3931,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3816,34 +3942,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "mi_n-tilak-varma",
-      "name": "N. Tilak Varma",
-      "team": "MI",
-      "role": "batter",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3859,7 +3958,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3870,34 +3969,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "mi_raghu-sharma",
-      "name": "Raghu Sharma",
-      "team": "MI",
-      "role": "bowler",
-      "is_uncapped": true,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3913,7 +3985,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3924,7 +3996,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3940,7 +4012,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -3951,34 +4023,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "mi_surya-kumar-yadav",
-      "name": "Surya Kumar Yadav",
-      "team": "MI",
-      "role": "batter",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3994,7 +4039,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4005,7 +4050,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4019,12 +4064,12 @@
       "role": "bowler",
       "is_uncapped": false,
       "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
+      "old_price": 5,
+      "initial_price": 5,
       "target_price": 4,
       "smoothed_price": 5,
       "final_price": 5,
-      "price_change": -1,
+      "price_change": 0,
       "matches_played": 2,
       "season_avg_points": -2.5,
       "recent_avg_points": -2.5,
@@ -4060,7 +4105,7 @@
       "score_basis": 70.5,
       "reliability_factor": 0.5,
       "adjusted_score": 35.25,
-      "percentile": 95.78,
+      "percentile": 94.78,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4086,10 +4131,10 @@
       "score_basis": 30.5,
       "reliability_factor": 0.5,
       "adjusted_score": 15.25,
-      "percentile": 77.51,
+      "percentile": 71.49,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 77.51",
+        "Target price mapped from percentile 71.49",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T14:00:00Z"
@@ -4114,10 +4159,9 @@
       "score_basis": 38.67,
       "reliability_factor": 0.75,
       "adjusted_score": 29,
-      "percentile": 92.37,
+      "percentile": 91.16,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Uncapped player price ceiling applied at 9 credits"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-06T14:00:00Z"
     },
@@ -4130,7 +4174,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -4141,9 +4185,11 @@
       "score_basis": 36,
       "reliability_factor": 0.5,
       "adjusted_score": 18,
-      "percentile": 80.52,
+      "percentile": 74.5,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 74.5",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T14:00:00Z"
     },
@@ -4167,7 +4213,7 @@
       "score_basis": 50.5,
       "reliability_factor": 0.5,
       "adjusted_score": 25.25,
-      "percentile": 88.35,
+      "percentile": 85.54,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4193,10 +4239,10 @@
       "score_basis": 35,
       "reliability_factor": 0.5,
       "adjusted_score": 17.5,
-      "percentile": 79.92,
+      "percentile": 73.9,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 79.92",
+        "Target price mapped from percentile 73.9",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T14:00:00Z"
@@ -4210,7 +4256,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -4221,9 +4267,11 @@
       "score_basis": 15.5,
       "reliability_factor": 0.5,
       "adjusted_score": 7.75,
-      "percentile": 65.86,
+      "percentile": 59.04,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 59.04",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T14:00:00Z"
     },
@@ -4236,7 +4284,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -4247,11 +4295,9 @@
       "score_basis": 27,
       "reliability_factor": 0.75,
       "adjusted_score": 20.25,
-      "percentile": 83.13,
+      "percentile": 78.31,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 83.13",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-06T14:00:00Z"
     },
@@ -4264,20 +4310,22 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 8,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
-      "matches_played": 3,
-      "season_avg_points": 5.33,
-      "recent_avg_points": 5.33,
+      "matches_played": 5,
+      "season_avg_points": 19.5,
+      "recent_avg_points": 17.67,
       "last_match_points": 5,
-      "score_basis": 5.33,
-      "reliability_factor": 0.75,
-      "adjusted_score": 4,
-      "percentile": 57.83,
+      "score_basis": 18.4,
+      "reliability_factor": 1,
+      "adjusted_score": 18.4,
+      "percentile": 75.5,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 75.5",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-06T14:00:00Z"
     },
@@ -4301,7 +4349,7 @@
       "score_basis": 4.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.25,
-      "percentile": 55.82,
+      "percentile": 48.59,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4327,9 +4375,37 @@
       "score_basis": 9,
       "reliability_factor": 0.5,
       "adjusted_score": 4.5,
-      "percentile": 59.84,
+      "percentile": 52.81,
       "calculation_notes": [
         "Used old_price for smoothing"
+      ],
+      "last_match_played_at_utc": "2026-04-03T14:00:00Z"
+    },
+    {
+      "player_id": "pbks_vyshak-vijaykumar",
+      "name": "Vyshak Vijaykumar",
+      "team": "PBKS",
+      "role": "bowler",
+      "is_uncapped": true,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 9,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 2,
+      "season_avg_points": 56,
+      "recent_avg_points": 56,
+      "last_match_points": 40,
+      "score_basis": 56,
+      "reliability_factor": 0.5,
+      "adjusted_score": 28,
+      "percentile": 89.96,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 89.96",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T14:00:00Z"
     },
@@ -4342,7 +4418,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4353,7 +4429,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4369,7 +4445,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4380,7 +4456,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4396,7 +4472,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4407,7 +4483,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4423,7 +4499,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4434,7 +4510,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4450,7 +4526,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4461,7 +4537,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4477,7 +4553,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4488,7 +4564,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4504,23 +4580,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 1,
+      "season_avg_points": 36,
+      "recent_avg_points": 36,
+      "last_match_points": 36,
+      "score_basis": 36,
+      "reliability_factor": 0.25,
+      "adjusted_score": 9,
+      "percentile": 60.84,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 60.84",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-01T14:00:00Z"
     },
     {
       "player_id": "pbks_pravin-dubey",
@@ -4531,7 +4608,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4542,7 +4619,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4558,7 +4635,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4569,7 +4646,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4585,7 +4662,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4596,7 +4673,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4612,7 +4689,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4623,7 +4700,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4639,7 +4716,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4650,34 +4727,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "pbks_vyshak-vijaykumar",
-      "name": "Vyshak Vijaykumar",
-      "team": "PBKS",
-      "role": "bowler",
-      "is_uncapped": true,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4693,7 +4743,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -4704,7 +4754,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4757,7 +4807,7 @@
       "score_basis": 71.5,
       "reliability_factor": 0.5,
       "adjusted_score": 35.75,
-      "percentile": 96.39,
+      "percentile": 95.18,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4783,10 +4833,10 @@
       "score_basis": 65.75,
       "reliability_factor": 0.5,
       "adjusted_score": 32.88,
-      "percentile": 93.98,
+      "percentile": 93.17,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 93.98",
+        "Target price mapped from percentile 93.17",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -4811,10 +4861,10 @@
       "score_basis": 64.5,
       "reliability_factor": 0.5,
       "adjusted_score": 32.25,
-      "percentile": 93.57,
+      "percentile": 92.77,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 93.57",
+        "Target price mapped from percentile 92.77",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -4828,7 +4878,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -4839,9 +4889,11 @@
       "score_basis": 37.25,
       "reliability_factor": 0.5,
       "adjusted_score": 18.63,
-      "percentile": 81.53,
+      "percentile": 76.31,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 76.31",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
     },
@@ -4854,7 +4906,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 10,
+      "target_price": 9,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -4865,11 +4917,9 @@
       "score_basis": 61,
       "reliability_factor": 0.5,
       "adjusted_score": 30.5,
-      "percentile": 92.77,
+      "percentile": 91.57,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 92.77",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
     },
@@ -4882,24 +4932,22 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 2,
-      "season_avg_points": 40.75,
-      "recent_avg_points": 40.75,
-      "last_match_points": 48,
-      "score_basis": 40.75,
-      "reliability_factor": 0.5,
-      "adjusted_score": 20.38,
-      "percentile": 83.53,
+      "matches_played": 5,
+      "season_avg_points": 19.5,
+      "recent_avg_points": 17.67,
+      "last_match_points": 5,
+      "score_basis": 18.4,
+      "reliability_factor": 1,
+      "adjusted_score": 18.4,
+      "percentile": 75.5,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 83.53",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
-      "last_match_played_at_utc": "2026-04-05T14:00:00Z"
+      "last_match_played_at_utc": "2026-04-06T14:00:00Z"
     },
     {
       "player_id": "rcb_bhuvneshwar-kumar",
@@ -4921,10 +4969,10 @@
       "score_basis": 52.75,
       "reliability_factor": 0.5,
       "adjusted_score": 26.38,
-      "percentile": 89.16,
+      "percentile": 86.35,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 89.16",
+        "Target price mapped from percentile 86.35",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -4938,22 +4986,24 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 9,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 2,
-      "season_avg_points": 25.5,
-      "recent_avg_points": 25.5,
-      "last_match_points": 22,
-      "score_basis": 25.5,
-      "reliability_factor": 0.5,
-      "adjusted_score": 12.75,
-      "percentile": 73.9,
+      "matches_played": 5,
+      "season_avg_points": 24.1,
+      "recent_avg_points": 23.83,
+      "last_match_points": 41.5,
+      "score_basis": 23.94,
+      "reliability_factor": 1,
+      "adjusted_score": 23.94,
+      "percentile": 82.53,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 82.53",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": "2026-04-05T14:00:00Z"
+      "last_match_played_at_utc": "2026-04-07T14:00:00Z"
     },
     {
       "player_id": "rcb_jitesh-sharma",
@@ -4975,7 +5025,7 @@
       "score_basis": 8,
       "reliability_factor": 0.5,
       "adjusted_score": 4,
-      "percentile": 58.43,
+      "percentile": 51.41,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4990,7 +5040,7 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
@@ -5001,10 +5051,36 @@
       "score_basis": 18.25,
       "reliability_factor": 0.5,
       "adjusted_score": 9.13,
-      "percentile": 67.87,
+      "percentile": 61.85,
+      "calculation_notes": [
+        "Used old_price for smoothing"
+      ],
+      "last_match_played_at_utc": "2026-04-05T14:00:00Z"
+    },
+    {
+      "player_id": "rcb_phil-salt",
+      "name": "Phil Salt",
+      "team": "RCB",
+      "role": "wicket_keeper",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 9,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 2,
+      "season_avg_points": 46,
+      "recent_avg_points": 46,
+      "last_match_points": 60,
+      "score_basis": 46,
+      "reliability_factor": 0.5,
+      "adjusted_score": 23,
+      "percentile": 81.12,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 67.87",
+        "Target price mapped from percentile 81.12",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -5029,10 +5105,10 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 54.42,
+      "percentile": 47.19,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.42",
+        "Target price mapped from percentile 47.19",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -5046,7 +5122,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5057,7 +5133,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5073,7 +5149,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5084,7 +5160,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5100,7 +5176,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5111,7 +5187,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5127,7 +5203,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5138,7 +5214,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5154,7 +5230,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5165,34 +5241,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "rcb_phil-salt",
-      "name": "Phil Salt",
-      "team": "RCB",
-      "role": "wicket_keeper",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5208,7 +5257,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5219,7 +5268,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5235,7 +5284,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5246,7 +5295,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5262,23 +5311,24 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "matches_played": 2,
+      "season_avg_points": 9,
+      "recent_avg_points": 9,
+      "last_match_points": 14,
+      "score_basis": 9,
+      "reliability_factor": 0.5,
+      "adjusted_score": 4.5,
+      "percentile": 52.81,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "No matches played; retained base price"
+        "Target price mapped from percentile 52.81",
+        "Applied smoothing against the target price"
       ],
-      "last_match_played_at_utc": null
+      "last_match_played_at_utc": "2026-04-03T14:00:00Z"
     },
     {
       "player_id": "rcb_venkatesh-iyer",
@@ -5289,7 +5339,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5300,7 +5350,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5316,7 +5366,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5327,7 +5377,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5343,7 +5393,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5354,7 +5404,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5370,7 +5420,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5381,7 +5431,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5486,7 +5536,7 @@
       "score_basis": 30.5,
       "reliability_factor": 0.75,
       "adjusted_score": 22.88,
-      "percentile": 85.94,
+      "percentile": 80.72,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5512,7 +5562,7 @@
       "score_basis": 36.33,
       "reliability_factor": 0.75,
       "adjusted_score": 27.25,
-      "percentile": 90.76,
+      "percentile": 87.95,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5538,10 +5588,10 @@
       "score_basis": 28,
       "reliability_factor": 0.25,
       "adjusted_score": 7,
-      "percentile": 64.06,
+      "percentile": 56.83,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.06",
+        "Target price mapped from percentile 56.83",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-03-30T14:00:00Z"
@@ -5566,7 +5616,7 @@
       "score_basis": 27.5,
       "reliability_factor": 0.5,
       "adjusted_score": 13.75,
-      "percentile": 75.3,
+      "percentile": 69.28,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5581,7 +5631,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -5592,11 +5642,9 @@
       "score_basis": 25,
       "reliability_factor": 0.75,
       "adjusted_score": 18.75,
-      "percentile": 82.33,
+      "percentile": 77.11,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 82.33",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-07T14:00:00Z"
     },
@@ -5609,20 +5657,22 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 9,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 3,
-      "season_avg_points": 23.17,
-      "recent_avg_points": 23.17,
+      "matches_played": 5,
+      "season_avg_points": 24.1,
+      "recent_avg_points": 23.83,
       "last_match_points": 41.5,
-      "score_basis": 23.17,
-      "reliability_factor": 0.75,
-      "adjusted_score": 17.38,
-      "percentile": 79.12,
+      "score_basis": 23.94,
+      "reliability_factor": 1,
+      "adjusted_score": 23.94,
+      "percentile": 82.53,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 82.53",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-07T14:00:00Z"
     },
@@ -5635,7 +5685,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -5646,9 +5696,11 @@
       "score_basis": 22,
       "reliability_factor": 0.5,
       "adjusted_score": 11,
-      "percentile": 69.88,
+      "percentile": 64.66,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 64.66",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-07T14:00:00Z"
     },
@@ -5672,7 +5724,7 @@
       "score_basis": 23.75,
       "reliability_factor": 0.5,
       "adjusted_score": 11.88,
-      "percentile": 71.08,
+      "percentile": 65.86,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5687,7 +5739,7 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
@@ -5698,11 +5750,41 @@
       "score_basis": 1,
       "reliability_factor": 0.25,
       "adjusted_score": 0.25,
-      "percentile": 52.61,
+      "percentile": 44.98,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 44.98",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T14:00:00Z"
+    },
+    {
+      "player_id": "rr_ravi-singh",
+      "name": "Ravi Singh",
+      "team": "RR",
+      "role": "wicket_keeper",
+      "is_uncapped": true,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 9,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": 1,
+      "matches_played": 2,
+      "season_avg_points": 48,
+      "recent_avg_points": 48,
+      "last_match_points": 50,
+      "score_basis": 48,
+      "reliability_factor": 0.5,
+      "adjusted_score": 24,
+      "percentile": 83.53,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 83.53",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-02T14:00:00Z"
     },
     {
       "player_id": "rr_adam-milne",
@@ -5713,7 +5795,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5724,7 +5806,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5740,7 +5822,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5751,7 +5833,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5767,7 +5849,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5778,7 +5860,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5794,7 +5876,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5805,7 +5887,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5821,7 +5903,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5832,7 +5914,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5848,7 +5930,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5859,34 +5941,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "rr_ravi-singh",
-      "name": "Ravi Singh",
-      "team": "RR",
-      "role": "wicket_keeper",
-      "is_uncapped": true,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 6,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5902,7 +5957,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5913,7 +5968,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5929,7 +5984,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5940,7 +5995,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5956,7 +6011,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5967,7 +6022,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5983,7 +6038,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -5994,7 +6049,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6010,7 +6065,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6021,7 +6076,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6037,7 +6092,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6048,7 +6103,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6101,7 +6156,7 @@
       "score_basis": 46.33,
       "reliability_factor": 0.75,
       "adjusted_score": 34.75,
-      "percentile": 94.98,
+      "percentile": 94.18,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6127,7 +6182,7 @@
       "score_basis": 44.83,
       "reliability_factor": 0.75,
       "adjusted_score": 33.62,
-      "percentile": 94.38,
+      "percentile": 93.57,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6172,14 +6227,14 @@
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
-      "matches_played": 3,
-      "season_avg_points": 24.83,
-      "recent_avg_points": 24.83,
+      "matches_played": 5,
+      "season_avg_points": 24.5,
+      "recent_avg_points": 29.67,
       "last_match_points": 0,
-      "score_basis": 24.83,
-      "reliability_factor": 0.75,
-      "adjusted_score": 18.62,
-      "percentile": 81.12,
+      "score_basis": 27.6,
+      "reliability_factor": 1,
+      "adjusted_score": 27.6,
+      "percentile": 89.16,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6205,10 +6260,10 @@
       "score_basis": 23.33,
       "reliability_factor": 0.75,
       "adjusted_score": 17.5,
-      "percentile": 79.52,
+      "percentile": 73.49,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 79.52",
+        "Target price mapped from percentile 73.49",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
@@ -6222,7 +6277,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -6233,9 +6288,11 @@
       "score_basis": 27.17,
       "reliability_factor": 0.75,
       "adjusted_score": 20.38,
-      "percentile": 83.94,
+      "percentile": 78.71,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 78.71",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
@@ -6259,7 +6316,7 @@
       "score_basis": 37.5,
       "reliability_factor": 0.75,
       "adjusted_score": 28.13,
-      "percentile": 91.57,
+      "percentile": 90.36,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6274,7 +6331,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -6285,9 +6342,11 @@
       "score_basis": 25,
       "reliability_factor": 0.75,
       "adjusted_score": 18.75,
-      "percentile": 82.33,
+      "percentile": 77.11,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 77.11",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
@@ -6311,7 +6370,7 @@
       "score_basis": 24.25,
       "reliability_factor": 0.5,
       "adjusted_score": 12.13,
-      "percentile": 72.29,
+      "percentile": 66.67,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6326,7 +6385,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -6337,9 +6396,11 @@
       "score_basis": 32,
       "reliability_factor": 0.25,
       "adjusted_score": 8,
-      "percentile": 66.27,
+      "percentile": 59.44,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 59.44",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
     },
@@ -6363,10 +6424,10 @@
       "score_basis": 14.5,
       "reliability_factor": 0.5,
       "adjusted_score": 7.25,
-      "percentile": 64.86,
+      "percentile": 57.63,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.86",
+        "Target price mapped from percentile 57.63",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
@@ -6391,7 +6452,7 @@
       "score_basis": 4.25,
       "reliability_factor": 0.5,
       "adjusted_score": 2.13,
-      "percentile": 55.02,
+      "percentile": 47.79,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6417,7 +6478,7 @@
       "score_basis": 5.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.75,
-      "percentile": 56.83,
+      "percentile": 49.6,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6432,7 +6493,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6443,7 +6504,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6459,7 +6520,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6470,7 +6531,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6486,7 +6547,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6497,7 +6558,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6513,7 +6574,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6524,7 +6585,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6540,7 +6601,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6551,7 +6612,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6567,7 +6628,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6578,7 +6639,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6594,7 +6655,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6605,7 +6666,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6621,7 +6682,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6632,7 +6693,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6648,7 +6709,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6659,7 +6720,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6675,7 +6736,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6686,7 +6747,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6702,7 +6763,7 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 5,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
@@ -6713,7 +6774,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 26.31,
+      "percentile": 22.49,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"

--- a/duels-backend.js
+++ b/duels-backend.js
@@ -114,6 +114,14 @@
       || fallback;
   }
 
+  function buildBundleLabel(duelRow, orderedEntries) {
+    const names = (orderedEntries || [])
+      .map((entry) => normalizeWhitespace(entry?.displayName || entry?.display_name || ''))
+      .filter(Boolean);
+    if (names.length >= 2) return `${names[0]} vs ${names[1]}`;
+    return normalizeWhitespace(duelRow?.label || names.join(' vs '));
+  }
+
   function makeBundleFromRows(duelRow, entryRows) {
     if (!duelRow) return null;
     const duelSlug = normalizeSlug(duelRow.slug || duelRow.id || '');
@@ -143,7 +151,7 @@
       duelRecord: {
         id: duelSlug,
         backendId: duelRow.id || null,
-        label: normalizeWhitespace(duelRow.label || orderedEntries.map((entry) => entry.displayName).join(' vs ')),
+        label: buildBundleLabel(duelRow, orderedEntries),
         visibility: duelRow.visibility || 'public',
         state: duelRow.state || 'draft',
         createdByUserId: duelRow.created_by_user_id || null,
@@ -637,6 +645,7 @@ function normalizeMiniFantasyEntryRow(row) {
         if (reservedHandle && reservedHandle !== normalizeSlug(currentUser.ownerId || '')) {
           throw new Error(`This duel slot is reserved for @${reservedHandle}.`);
         }
+        const updatedAt = new Date().toISOString();
         await restRequest(config.tables.duelEntries, {
           method: 'PATCH',
           query: {
@@ -647,7 +656,31 @@ function normalizeMiniFantasyEntryRow(row) {
             owner_user_id: currentUser.userId,
             owner_handle: currentUser.ownerId,
             display_name: currentUser.displayName,
-            updated_at: new Date().toISOString()
+            updated_at: updatedAt
+          },
+          accessToken: activeSession.access_token,
+          prefer: 'return=representation'
+        });
+        const nextEntryRows = loaded.entryRows.map((entry) => (
+          entry.id === openEntry.id
+            ? {
+                ...entry,
+                owner_user_id: currentUser.userId,
+                owner_handle: currentUser.ownerId,
+                display_name: currentUser.displayName,
+                updated_at: updatedAt
+              }
+            : entry
+        ));
+        await restRequest(config.tables.duels, {
+          method: 'PATCH',
+          query: {
+            id: `eq.${loaded.duelRow.id}`,
+            select: 'id'
+          },
+          body: {
+            label: buildBundleLabel(loaded.duelRow, nextEntryRows),
+            updated_at: updatedAt
           },
           accessToken: activeSession.access_token,
           prefer: 'return=representation'

--- a/index.html
+++ b/index.html
@@ -5049,9 +5049,17 @@ function titleBandScore(pick, live){
       };
     }
 
+    function visibleDuelLabel(matchup){
+      if (!matchup) return '';
+      const nameA = normalizeWhitespace(matchup?.a?.name || '');
+      const nameB = normalizeWhitespace(matchup?.b?.name || '');
+      if (nameA && nameB) return `${nameA} vs ${nameB}`;
+      return normalizeWhitespace(matchup?.label || [nameA, nameB].filter(Boolean).join(' vs '));
+    }
+
     function buildInviteMessage(duelId){
       const bundle = findCustomBundleByDuelId(ACTIVE_ROOM?.slug || DEFAULT_ROOM_SLUG, duelId);
-      const label = bundle?.duelRecord?.label || activeMatchup()?.label || 'SP Cup Duel';
+      const label = visibleDuelLabel(activeMatchup()) || bundle?.duelRecord?.label || 'SP Cup Duel';
       const duelCode = duelCodeLabel(duelId);
       const link = buildDuelShareUrl(duelId);
       return [
@@ -5091,7 +5099,7 @@ function titleBandScore(pick, live){
       const lifecycle = matchup.lifecycle || deriveMatchupLifecycle(matchup, ACTIVE_ROOM);
       return {
         duelId: matchup.id,
-        label: matchup.label,
+        label: visibleDuelLabel(matchup),
         source: activeCustomBundle()?.source || 'fixture',
         currentUser: CURRENT_USER ? {
           displayName: CURRENT_USER.displayName,
@@ -6165,10 +6173,10 @@ function titleBandScore(pick, live){
         <div class="duel-picker">
           <label for="duelPicker">Browse duel</label>
           <select id="duelPicker" aria-label="Browse public duel">
-            ${pickerMatchups.map((item) => `<option value="${escapeHtml(item.id)}" ${item.id === matchup.id ? 'selected' : ''}>${escapeHtml(item.label || `${item.a.name} vs ${item.b.name}`)}${item.state !== 'locked' ? ' (Waiting)' : ''}</option>`).join('')}
+            ${pickerMatchups.map((item) => `<option value="${escapeHtml(item.id)}" ${item.id === matchup.id ? 'selected' : ''}>${escapeHtml(visibleDuelLabel(item))}${item.state !== 'locked' ? ' (Waiting)' : ''}</option>`).join('')}
           </select>
         </div>
-        <div class="pill">Active duel: ${escapeHtml(matchup.label || `${matchup.a.name} vs ${matchup.b.name}`)}${escapeHtml(waitingTag)}</div>
+        <div class="pill">Active duel: ${escapeHtml(visibleDuelLabel(matchup))}${escapeHtml(waitingTag)}</div>
         <div class="pill">Visibility: public duel page${pickerMatchups.length ? ` | ${pickerMatchups.length} shown` : ''}</div>
         <div class="pill">Series: ${escapeHtml(ACTIVE_ROOM.name || ACTIVE_ROOM.slug || 'Duels')}</div>
         ${fallbackTag ? `<div class="pill">${escapeHtml(fallbackTag)}</div>` : ''}
@@ -6207,10 +6215,10 @@ function titleBandScore(pick, live){
         <div class="duel-picker">
           <label for="duelPicker">Jump to duel</label>
           <select id="duelPicker" aria-label="Browse public duel">
-            ${MATCHUPS.map((item) => `<option value="${escapeHtml(item.id)}" ${item.id === matchup.id ? 'selected' : ''}>${escapeHtml(item.label || `${item.a.name} vs ${item.b.name}`)}${item.state !== 'locked' ? ' (Waiting)' : ''}</option>`).join('')}
+            ${MATCHUPS.map((item) => `<option value="${escapeHtml(item.id)}" ${item.id === matchup.id ? 'selected' : ''}>${escapeHtml(visibleDuelLabel(item))}${item.state !== 'locked' ? ' (Waiting)' : ''}</option>`).join('')}
           </select>
         </div>
-        <div class="pill">Active duel: ${escapeHtml(matchup.label || `${matchup.a.name} vs ${matchup.b.name}`)}${escapeHtml(waitingTag)}</div>
+        <div class="pill">Active duel: ${escapeHtml(visibleDuelLabel(matchup))}${escapeHtml(waitingTag)}</div>
         <div class="pill">Visibility: public duel page | ${MATCHUPS.length} listed</div>
         <div class="pill">Series: ${escapeHtml(ACTIVE_ROOM.name || ACTIVE_ROOM.slug || 'Duels')}</div>
         ${fallbackTag ? `<div class="pill">${escapeHtml(fallbackTag)}</div>` : ''}
@@ -6249,7 +6257,7 @@ function titleBandScore(pick, live){
         }
 
         const updatedLabel = formatTimestamp(boardUpdatedAt || item.updatedAt || ACTIVE_ROOM.updatedAt || null);
-        const duelLabel = item.label || `${item.a.name} vs ${item.b.name}`;
+        const duelLabel = visibleDuelLabel(item);
         const activeClass = item.id === activeId ? 'active' : '';
         const ctaLabel = item.id === activeId ? 'Viewing duel page' : 'Open duel page';
 
@@ -6345,7 +6353,7 @@ function titleBandScore(pick, live){
       matchup = withFreshLifecycle(matchup);
       const updatedAt = latestBoardUpdatedAt() || matchup.updatedAt || ACTIVE_ROOM?.updatedAt || null;
       const createdAt = matchup.createdAt || ACTIVE_ROOM?.createdAt || null;
-      const duelLabel = matchup.label || `${matchup.a.name} vs ${matchup.b.name}`;
+      const duelLabel = visibleDuelLabel(matchup);
       const lifecycle = matchup.lifecycle || deriveMatchupLifecycle(matchup, ACTIVE_ROOM);
       const status = lifecycle.status || 'draft';
       const isLive = status === 'live';
@@ -6439,7 +6447,7 @@ function titleBandScore(pick, live){
       const orderedDuels = sortedDirectoryDuels();
       if (directoryFilter === 'mine' && !CURRENT_USER) directoryFilter = 'all';
       const visibleDuels = filteredDirectoryDuels(orderedDuels);
-      const activeLabel = matchup.label || `${matchup.a.name} vs ${matchup.b.name}`;
+      const activeLabel = visibleDuelLabel(matchup);
       const statusLabel = matchup.lifecycle?.status === 'live' ? 'Live duel' : lifecycleHeadline(matchup.lifecycle);
       const fallbackTag = requestedDuelMissing ? 'Requested duel was not found, so this page fell back to the first available duel.' : '';
       if (activeView !== 'fantasy') {

--- a/index.html
+++ b/index.html
@@ -5051,10 +5051,10 @@ function titleBandScore(pick, live){
 
     function visibleDuelLabel(matchup){
       if (!matchup) return '';
-      const nameA = normalizeWhitespace(matchup?.a?.name || '');
-      const nameB = normalizeWhitespace(matchup?.b?.name || '');
+      const nameA = normalizeTextValue(matchup?.a?.name || '');
+      const nameB = normalizeTextValue(matchup?.b?.name || '');
       if (nameA && nameB) return `${nameA} vs ${nameB}`;
-      return normalizeWhitespace(matchup?.label || [nameA, nameB].filter(Boolean).join(' vs '));
+      return normalizeTextValue(matchup?.label || [nameA, nameB].filter(Boolean).join(' vs '));
     }
 
     function buildInviteMessage(duelId){

--- a/index.html
+++ b/index.html
@@ -6926,7 +6926,8 @@ function titleBandScore(pick, live){
         const ordered = ranking.length ? ranking : Object.keys(standings);
         ordered.forEach((team, idx) => {
           const s = standings[team] || {};
-          rows.push({ rank: displayRank(team, idx + 1), name: team, value: `${s.points ?? 0} pts`, context: `Played ${s.played ?? 0} • W ${s.wins ?? 0} • L ${s.losses ?? 0} • NRR ${standingNrrValue(s).toFixed(3)}` });
+          const noResult = s.noResult ?? 0;
+          rows.push({ rank: displayRank(team, idx + 1), name: team, value: `${s.points ?? 0} pts`, context: `Played ${s.played ?? 0} • W ${s.wins ?? 0} • L ${s.losses ?? 0} • NR ${noResult} • NRR ${standingNrrValue(s).toFixed(3)}` });
         });
         return { summary: categoryKey === 'titleWinner' ? 'Current title-race order from the live standings.' : 'Current table order. For Bottom of table, the lowest side is the live target.', rows };
       }

--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -156,6 +156,19 @@ export function normalizeName(value) {
 
 const UNCAPPED_MVP_PLAYER_KEYS = new Set(UNCAPPED_MVP_PLAYERS.map((name) => normalizeName(name)));
 
+// Keep a conservative alias map for common score-feed spelling drift.
+const NAME_TOKEN_ALIASES = Object.freeze({
+  mohd: 'mohammad',
+  mohd0: 'mohammad',
+  mohds: 'mohammad',
+  mohamad: 'mohammad',
+  mohamed: 'mohammad',
+  mohammed: 'mohammad',
+  mohammedh: 'mohammad',
+  mohamad0: 'mohammad',
+  md: 'mohammad'
+});
+
 export function slugify(value) {
   return normalizeWhitespace(value)
     .normalize('NFKD')
@@ -177,6 +190,130 @@ export function currentRoleOverride(teamCode, playerName) {
 
 function tokenizeName(value) {
   return normalizeName(value).split(' ').filter(Boolean);
+}
+
+function normalizeAliasToken(token) {
+  return NAME_TOKEN_ALIASES[token] || token;
+}
+
+function tokenizeAliasName(value, { dropInitials = false } = {}) {
+  return tokenizeName(value)
+    .map(normalizeAliasToken)
+    .filter((token) => !dropInitials || token.length > 1);
+}
+
+function addAliasKey(keys, tokens) {
+  const normalizedTokens = (Array.isArray(tokens) ? tokens : []).filter(Boolean);
+  if (!normalizedTokens.length) return;
+  keys.add(normalizedTokens.join(' '));
+  if (normalizedTokens.length > 1) {
+    keys.add([...normalizedTokens].sort().join(' '));
+  }
+}
+
+function buildNameAliasKeys(value) {
+  const rawTokens = tokenizeAliasName(value);
+  const significantTokens = tokenizeAliasName(value, { dropInitials: true });
+  const keys = new Set();
+
+  addAliasKey(keys, rawTokens);
+  if (significantTokens.length && significantTokens.length !== rawTokens.length) {
+    addAliasKey(keys, significantTokens);
+  }
+
+  if (rawTokens.length >= 3) {
+    addAliasKey(keys, [rawTokens[0], rawTokens[rawTokens.length - 1]]);
+    addAliasKey(keys, rawTokens.slice(0, 2));
+  }
+
+  if (significantTokens.length >= 2) {
+    addAliasKey(keys, [significantTokens[0], significantTokens[significantTokens.length - 1]]);
+    addAliasKey(keys, [significantTokens[0].charAt(0), significantTokens[significantTokens.length - 1]]);
+    if (significantTokens.length >= 3) {
+      addAliasKey(keys, significantTokens.slice(0, 2));
+      addAliasKey(keys, [significantTokens[0].charAt(0), significantTokens[1]]);
+    }
+  }
+
+  return [...keys].filter(Boolean);
+}
+
+function countSharedAliasTokens(a, b) {
+  const tokensA = new Set(tokenizeAliasName(a, { dropInitials: true }));
+  const tokensB = new Set(tokenizeAliasName(b, { dropInitials: true }));
+  let shared = 0;
+  tokensA.forEach((token) => {
+    if (tokensB.has(token)) shared += 1;
+  });
+  return shared;
+}
+
+function areAliasTokensSubset(a, b) {
+  return a.length > 0 && a.every((token) => b.includes(token));
+}
+
+function mergeHistoryMatches(playerName, histories = []) {
+  const mergedPoints = {};
+  let resolvedName = normalizeWhitespace(playerName);
+  let lastMatchPlayedAtUtc = null;
+
+  histories.forEach((history) => {
+    const pointsByMatchNo = history?.points_by_match_no || {};
+    Object.entries(pointsByMatchNo).forEach(([matchNo, points]) => {
+      const numericMatchNo = Number(matchNo);
+      if (!Number.isFinite(numericMatchNo) || numericMatchNo <= 0) return;
+      mergedPoints[numericMatchNo] = mergedPoints[numericMatchNo] == null
+        ? roundTo(toNumber(points, 0), 2)
+        : Math.max(mergedPoints[numericMatchNo], roundTo(toNumber(points, 0), 2));
+    });
+    if (!resolvedName || String(history?.player_name || '').length > resolvedName.length) {
+      resolvedName = normalizeWhitespace(history?.player_name || resolvedName);
+    }
+    const playedAt = history?.last_match_played_at_utc || null;
+    if (playedAt && (!lastMatchPlayedAtUtc || Date.parse(playedAt) > Date.parse(lastMatchPlayedAtUtc))) {
+      lastMatchPlayedAtUtc = playedAt;
+    }
+  });
+
+  const orderedMatchNos = Object.keys(mergedPoints).map(Number).sort((a, b) => a - b);
+  return {
+    player_name: resolvedName || normalizeWhitespace(playerName),
+    match_points: orderedMatchNos.map((matchNo) => mergedPoints[matchNo]),
+    points_by_match_no: Object.fromEntries(orderedMatchNos.map((matchNo) => [matchNo, mergedPoints[matchNo]])),
+    matches_played: orderedMatchNos.length,
+    last_match_played_at_utc: lastMatchPlayedAtUtc
+  };
+}
+
+export function resolvePlayerHistory(playerName, historyMap = new Map()) {
+  if (!(historyMap instanceof Map) || !normalizeWhitespace(playerName)) {
+    return null;
+  }
+
+  const targetAliasKeys = new Set(buildNameAliasKeys(playerName));
+  const targetSignificantTokens = tokenizeAliasName(playerName, { dropInitials: true });
+  const matches = [];
+
+  historyMap.forEach((history, fallbackKey) => {
+    const candidateName = history?.player_name || fallbackKey;
+    const directAliasMatch = buildNameAliasKeys(candidateName).some((aliasKey) => targetAliasKeys.has(aliasKey));
+    if (!directAliasMatch) {
+      const candidateTokens = tokenizeAliasName(candidateName, { dropInitials: true });
+      const sharedTokens = countSharedAliasTokens(playerName, candidateName);
+      const subsetMatch =
+        areAliasTokensSubset(targetSignificantTokens, candidateTokens) ||
+        areAliasTokensSubset(candidateTokens, targetSignificantTokens);
+      const overlap =
+        sharedTokens / Math.max(new Set(targetSignificantTokens).size || 1, new Set(candidateTokens).size || 1);
+      if (sharedTokens < 2 || (!subsetMatch && overlap < 0.67)) {
+        return;
+      }
+    }
+    matches.push(history);
+  });
+
+  if (!matches.length) return null;
+  return mergeHistoryMatches(playerName, matches);
 }
 
 function tokenOverlapScore(a, b) {
@@ -441,8 +578,9 @@ export function buildPricingJobFromLiveData({
   Object.entries(squads || {}).forEach(([teamCode, squadPlayers]) => {
     (Array.isArray(squadPlayers) ? squadPlayers : []).forEach((playerName) => {
       const canonicalName = normalizeName(playerName);
-      const history = historyMap.get(canonicalName) || {
+      const history = resolvePlayerHistory(playerName, historyMap) || {
         match_points: [],
+        points_by_match_no: {},
         matches_played: 0,
         last_match_played_at_utc: null
       };
@@ -674,7 +812,7 @@ export function buildMiniFantasyPlayerPointsIndex({
   const index = new Map();
   Object.entries(squads || {}).forEach(([teamCode, squadPlayers]) => {
     (Array.isArray(squadPlayers) ? squadPlayers : []).forEach((playerName) => {
-      const history = historyMap.get(normalizeName(playerName));
+      const history = resolvePlayerHistory(playerName, historyMap);
       index.set(buildMiniFantasyPlayerId(teamCode, playerName), {
         player_id: buildMiniFantasyPlayerId(teamCode, playerName),
         name: playerName,

--- a/scripts/update-live-data.mjs
+++ b/scripts/update-live-data.mjs
@@ -225,8 +225,81 @@ function oversToBalls(value) {
   return (Number(whole || 0) * 6) + Number(frac || 0);
 }
 
+function ballsToOversNotation(balls) {
+  const safeBalls = Math.max(0, Number(balls || 0));
+  const whole = Math.floor(safeBalls / 6);
+  const remainder = safeBalls % 6;
+  return remainder ? `${whole}.${remainder}` : String(whole);
+}
+
 function allOutUsesFullQuota(wickets, balls, quota = 120) {
   return Number(wickets || 0) >= 10 ? quota : balls;
+}
+
+function isDismissedBattingEntry(entry) {
+  const text = normalizeName(entry?.['dismissal-text'] || entry?.dismissal || '').toLowerCase();
+  if (!text) return false;
+  if (text === 'batting') return false;
+  if (text === 'not out') return false;
+  if (text.includes('not out')) return false;
+  if (text.includes('retired hurt')) return false;
+  return true;
+}
+
+function deriveScoreLineFromInnings(innings) {
+  const inning = normalizeName(innings?.inning);
+  if (!inning) return null;
+
+  const totalsRuns = Number(
+    innings?.totals?.r
+    ?? innings?.totals?.runs
+    ?? innings?.total?.r
+    ?? innings?.total?.runs
+    ?? 0
+  );
+  const battingRuns = safeArray(innings?.batting).reduce((sum, batter) => sum + Number(batter?.r || 0), 0);
+  const extrasObject = innings?.extras && typeof innings.extras === 'object' ? innings.extras : {};
+  const extrasRuns = Object.values(extrasObject).reduce((sum, value) => sum + Number(value || 0), 0);
+  const bowlingRuns = safeArray(innings?.bowling).reduce((sum, bowler) => sum + Number(bowler?.r || 0), 0);
+  const bowlingExtras = safeArray(innings?.bowling).reduce((sum, bowler) => sum + Number(bowler?.nb || 0) + Number(bowler?.wd || 0), 0);
+  const runs = totalsRuns > 0 ? totalsRuns : Math.max(bowlingRuns, battingRuns + Math.max(extrasRuns, bowlingExtras));
+
+  const totalsWickets = Number(
+    innings?.totals?.w
+    ?? innings?.totals?.wkts
+    ?? innings?.total?.w
+    ?? innings?.total?.wkts
+    ?? innings?.wickets
+    ?? 0
+  );
+  const bowlingWickets = safeArray(innings?.bowling).reduce((sum, bowler) => sum + Number(bowler?.w || 0), 0);
+  const battingWickets = safeArray(innings?.batting).reduce((sum, batter) => sum + (isDismissedBattingEntry(batter) ? 1 : 0), 0);
+  const wickets = Math.max(totalsWickets, bowlingWickets, battingWickets);
+
+  const totalsOvers = innings?.totals?.o ?? innings?.totals?.overs ?? innings?.total?.o ?? innings?.total?.overs ?? innings?.o;
+  const bowlingBalls = safeArray(innings?.bowling).reduce((sum, bowler) => sum + oversToBalls(bowler?.o), 0);
+  const overs = totalsOvers != null && totalsOvers !== '' ? String(totalsOvers) : ballsToOversNotation(bowlingBalls);
+
+  return { inning, r: runs, w: wickets, o: overs };
+}
+
+function scoreLinesForScorecard(scorecardData, inningsBlocks) {
+  const topScores = safeArray(scorecardData?.score);
+  if (topScores.length >= 2) return topScores;
+  return safeArray(inningsBlocks).map((innings) => deriveScoreLineFromInnings(innings)).filter(Boolean);
+}
+
+function isNoResultStatus(scorecardData, winner, teamA, teamB) {
+  if (winner === teamA || winner === teamB) return false;
+  const status = normalizeName(scorecardData?.status).toLowerCase();
+  const winnerText = normalizeName(scorecardData?.matchWinner || '').toLowerCase();
+  return (
+    winnerText === 'no winner' ||
+    status.includes('no result') ||
+    status.includes('abandon') ||
+    status.includes('abandoned') ||
+    status.includes('washout')
+  );
 }
 
 function createEmptyAggregates() {
@@ -1015,6 +1088,7 @@ function ensureStandingTeam(map, team) {
       played: 0,
       wins: 0,
       losses: 0,
+      noResult: 0,
       points: 0,
       runsFor: 0,
       ballsFaced: 0,
@@ -1144,7 +1218,7 @@ function buildProcessedMatchRefs(matchList, processedKeys, processedIds = []) {
 
 function applyScorecardToAggregates(aggregates, scorecardData, { isFinal = true } = {}) {
   const inningsBlocks = safeArray(scorecardData.scorecard);
-  const topScores = safeArray(scorecardData.score);
+  const topScores = scoreLinesForScorecard(scorecardData, inningsBlocks);
   const participants = new Set();
 
   for (const innings of inningsBlocks) {
@@ -1196,30 +1270,32 @@ function applyScorecardToAggregates(aggregates, scorecardData, { isFinal = true 
   if (!isFinal) return;
 
   const teams = safeArray(scorecardData.teams).map(normalizeName);
-  if (teams.length === 2 && topScores.length >= 2) {
+  if (teams.length === 2) {
     const [teamA, teamB] = teams;
     const standingA = ensureStandingTeam(aggregates.standings, teamA);
     const standingB = ensureStandingTeam(aggregates.standings, teamB);
     standingA.played += 1;
     standingB.played += 1;
 
-    const inningMap = {};
-    for (const s of topScores) inningMap[parseTeamFromInningName(s?.inning)] = s;
+    if (topScores.length >= 2) {
+      const inningMap = {};
+      for (const s of topScores) inningMap[parseTeamFromInningName(s?.inning)] = s;
 
-    const sa = inningMap[teamA];
-    const sb = inningMap[teamB];
-    if (sa && sb) {
-      const ballsA = allOutUsesFullQuota(sa.w, oversToBalls(sa.o));
-      const ballsB = allOutUsesFullQuota(sb.w, oversToBalls(sb.o));
-      standingA.runsFor += Number(sa.r || 0);
-      standingA.ballsFaced += ballsA;
-      standingA.runsAgainst += Number(sb.r || 0);
-      standingA.ballsBowled += ballsB;
+      const sa = inningMap[teamA];
+      const sb = inningMap[teamB];
+      if (sa && sb) {
+        const ballsA = allOutUsesFullQuota(sa.w, oversToBalls(sa.o));
+        const ballsB = allOutUsesFullQuota(sb.w, oversToBalls(sb.o));
+        standingA.runsFor += Number(sa.r || 0);
+        standingA.ballsFaced += ballsA;
+        standingA.runsAgainst += Number(sb.r || 0);
+        standingA.ballsBowled += ballsB;
 
-      standingB.runsFor += Number(sb.r || 0);
-      standingB.ballsFaced += ballsB;
-      standingB.runsAgainst += Number(sa.r || 0);
-      standingB.ballsBowled += ballsA;
+        standingB.runsFor += Number(sb.r || 0);
+        standingB.ballsFaced += ballsB;
+        standingB.runsAgainst += Number(sa.r || 0);
+        standingB.ballsBowled += ballsA;
+      }
     }
 
     const winner = normalizeName(scorecardData.matchWinner);
@@ -1231,6 +1307,11 @@ function applyScorecardToAggregates(aggregates, scorecardData, { isFinal = true 
       standingB.wins += 1;
       standingB.points += 2;
       standingA.losses += 1;
+    } else if (isNoResultStatus(scorecardData, winner, teamA, teamB)) {
+      standingA.noResult += 1;
+      standingB.noResult += 1;
+      standingA.points += 1;
+      standingB.points += 1;
     }
   }
 }

--- a/tests/duels-backend.wiring.test.mjs
+++ b/tests/duels-backend.wiring.test.mjs
@@ -22,6 +22,9 @@ test('backend config, adapter, and setup docs are present for real auth + duel a
   assert.match(backendJs, /listPublicBundles/);
   assert.match(backendJs, /createPublicDuel/);
   assert.match(backendJs, /claimOpenEntry/);
+  assert.match(backendJs, /function buildBundleLabel\(/);
+  assert.match(backendJs, /label:\s*buildBundleLabel\(duelRow,\s*orderedEntries\)/);
+  assert.match(backendJs, /label:\s*buildBundleLabel\(loaded\.duelRow,\s*nextEntryRows\)/);
   assert.match(backendJs, /saveOwnedEntry/);
   assert.match(backendJs, /listMiniFantasyEntries/);
   assert.match(backendJs, /listPublicMiniFantasyEntries/);

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -9,6 +9,7 @@ import {
   deriveCompletedMatchHistories,
   generateMiniFantasyPriceBook,
   getMiniFantasyOpenFixtures,
+  resolvePlayerHistory,
   validateMiniFantasyEntry
 } from '../mini-fantasy/contest-engine.js';
 
@@ -70,6 +71,76 @@ test('deriveCompletedMatchHistories keeps zero-point appearances when playerMatc
   assert.equal(histories.get('player a')?.matches_played, 2);
   assert.deepEqual(histories.get('player b')?.match_points, [5]);
   assert.deepEqual(histories.get('player c')?.match_points, [60]);
+});
+
+test('resolvePlayerHistory matches safe alias variations used by squad lists', () => {
+  const liveData = {
+    meta: {
+      scoreHistory: [
+        {
+          processedMatchCount: 1,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Mohammed Shami': 1,
+                  'Manimaran Siddharth': 1,
+                  'Digvesh Singh Rathi': 1,
+                  'Vijaykumar Vyshak': 1,
+                  'Tilak Varma': 1
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Mohammed Shami': { score: 20 },
+                'Manimaran Siddharth': { score: 30 },
+                'Digvesh Singh Rathi': { score: 10 },
+                'Vijaykumar Vyshak': { score: 25 },
+                'Tilak Varma': { score: 15 }
+              }
+            }
+          }
+        },
+        {
+          processedMatchCount: 2,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Mohammed Shami': 2,
+                  'Manimaran Siddharth': 1,
+                  'Digvesh Singh Rathi': 1,
+                  'Vijaykumar Vyshak': 2,
+                  'Tilak Varma': 2
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Mohammed Shami': { score: 50 },
+                'Manimaran Siddharth': { score: 30 },
+                'Digvesh Singh Rathi': { score: 10 },
+                'Vijaykumar Vyshak': { score: 60 },
+                'Tilak Varma': { score: 25 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  };
+
+  const histories = deriveCompletedMatchHistories(liveData, [
+    { match_no: 1, datetime_utc: '2026-04-01T14:00:00Z' },
+    { match_no: 2, datetime_utc: '2026-04-02T14:00:00Z' }
+  ]);
+
+  assert.deepEqual(resolvePlayerHistory('Mohammad Shami', histories)?.match_points, [20, 30]);
+  assert.deepEqual(resolvePlayerHistory('M. Siddharth', histories)?.match_points, [30]);
+  assert.deepEqual(resolvePlayerHistory('Digvesh Singh', histories)?.match_points, [10]);
+  assert.deepEqual(resolvePlayerHistory('Vyshak Vijaykumar', histories)?.match_points, [25, 35]);
+  assert.deepEqual(resolvePlayerHistory('N. Tilak Varma', histories)?.match_points, [15, 10]);
 });
 
 test('getMiniFantasyOpenFixtures opens Match 14 now and later fixtures from the day-before window', () => {
@@ -243,6 +314,99 @@ test('generateMiniFantasyPriceBook marks uncapped players and caps them at 9 cre
   assert.equal(sameer.is_uncapped, true);
   assert.equal(sameer.final_price, 9);
   assert.match(sameer.calculation_notes.join(' '), /uncapped player price ceiling applied at 9 credits/i);
+});
+
+test('generateMiniFantasyPriceBook keeps alias-matched LSG bowlers from falling back to blank stats', () => {
+  const liveData = {
+    fetchedAt: '2026-04-08T00:10:00Z',
+    meta: {
+      scoreHistory: [
+        {
+          processedMatchCount: 5,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Mohammed Shami': 1,
+                  'Manimaran Siddharth': 1,
+                  'Veteran Bowler': 1
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Mohammed Shami': { score: 23 },
+                'Manimaran Siddharth': { score: 30 },
+                'Veteran Bowler': { score: 10 }
+              }
+            }
+          }
+        },
+        {
+          processedMatchCount: 10,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Mohammed Shami': 2,
+                  'Manimaran Siddharth': 1,
+                  'Veteran Bowler': 2
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Mohammed Shami': { score: 69 },
+                'Manimaran Siddharth': { score: 30 },
+                'Veteran Bowler': { score: 20 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  };
+  const schedule = [
+    { match_no: 5, datetime_utc: '2026-04-01T14:00:00Z', home_team: 'Lucknow Super Giants', away_team: 'Mumbai Indians' },
+    { match_no: 10, datetime_utc: '2026-04-05T14:00:00Z', home_team: 'Lucknow Super Giants', away_team: 'Rajasthan Royals' },
+    { match_no: 14, datetime_utc: '2026-04-08T14:00:00Z', home_team: 'Lucknow Super Giants', away_team: 'Delhi Capitals' }
+  ];
+  const squads = {
+    LSG: ['Mohammad Shami', 'M. Siddharth'],
+    DC: ['Veteran Bowler']
+  };
+  const teamRoles = {
+    teams: {
+      LSG: {
+        players: {
+          'Mohammad Shami': 'bowler',
+          'M. Siddharth': 'bowler'
+        }
+      },
+      DC: {
+        players: {
+          'Veteran Bowler': 'bowler'
+        }
+      }
+    }
+  };
+
+  const priceBook = generateMiniFantasyPriceBook({
+    liveData,
+    schedule,
+    squads,
+    teamRoles,
+    asOfUtc: '2026-04-08T00:10:00Z'
+  });
+
+  const shami = priceBook.players.find((player) => player.player_id === buildMiniFantasyPlayerId('LSG', 'Mohammad Shami'));
+  const siddharth = priceBook.players.find((player) => player.player_id === buildMiniFantasyPlayerId('LSG', 'M. Siddharth'));
+
+  assert.equal(shami.matches_played, 2);
+  assert.equal(shami.last_match_played_at_utc, '2026-04-05T14:00:00Z');
+  assert.ok(shami.final_price > 6);
+  assert.equal(siddharth.matches_played, 1);
+  assert.equal(siddharth.last_match_played_at_utc, '2026-04-01T14:00:00Z');
 });
 
 test('buildMiniFantasyLeaderboard ranks saved users by scored mini fantasy points', () => {

--- a/tests/page.directory-wiring.test.mjs
+++ b/tests/page.directory-wiring.test.mjs
@@ -32,11 +32,12 @@ test('public duel directory wiring exists in the page shell', async () => {
   assert.match(html, /duels-backend\.js/);
   assert.match(html, /mini-fantasy\/contest-engine\.js/);
   assert.match(html, /function sortedDirectoryDuels\(/);
-  assert.match(html, /function buildDuelShareUrl\(/);
-  assert.match(html, /function joinDuelByCode\(/);
-  assert.match(html, /function copyDuelCode\(/);
-  assert.match(html, /function copyInviteMessage\(/);
-  assert.match(html, /function renderHeroActions\(/);
+    assert.match(html, /function buildDuelShareUrl\(/);
+    assert.match(html, /function joinDuelByCode\(/);
+    assert.match(html, /function copyDuelCode\(/);
+    assert.match(html, /function copyInviteMessage\(/);
+    assert.match(html, /function visibleDuelLabel\(/);
+    assert.match(html, /function renderHeroActions\(/);
   assert.match(html, /function renderParticipantBanner\(/);
   assert.match(html, /function syncSurfaceDrawers\(/);
   assert.match(html, /function renderProfilePanel\(/);

--- a/tests/page.smoke.spec.mjs
+++ b/tests/page.smoke.spec.mjs
@@ -52,6 +52,7 @@ test('duels beta supports picker search, clash resolution, and armed start gatin
   await expect(page.locator('#leaguePill')).toContainText('Duels: SP Cup 2026');
   await expect(page.getByRole('button', { name: 'Duel', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Mini Fantasy', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Duel', exact: true }).click();
   await expect(page.locator('#browseDuelsButton')).toBeVisible();
   await expect(page.locator('#createDuelButton')).toBeVisible();
   await expect(page.locator('#profileChipButton')).toContainText('Sign in');
@@ -220,13 +221,14 @@ test('mini fantasy opens Match 14 early, shows future submit windows, and ranks 
 
   await page.goto('http://127.0.0.1:4173/index.html?room=sp-cup-2026');
 
+  await expect(page.locator('#profileChipButton')).toBeVisible();
   await page.locator('#profileChipButton').click();
+  await expect(page.locator('#profileDrawer')).toBeVisible();
   await page.locator('#authDisplayName').fill('Mini Bala');
   await page.locator('#authOwnerId').fill('mini-bala');
   await page.locator('#authForm button[type="submit"]').click();
   await page.locator('#profileDrawer [data-close-drawer="profile"]').click();
 
-  await page.getByRole('button', { name: 'Mini Fantasy', exact: true }).click();
   await expect(page.locator('#leagueTitle')).toContainText('SP Cup 2026 Mini Fantasy');
   await expect(page.getByRole('button', { name: 'Duel', exact: true })).toBeVisible();
   await expect(page.locator('#browseDuelsButton')).toHaveCount(0);

--- a/tests/update-live-data.scorecard-cache.test.mjs
+++ b/tests/update-live-data.scorecard-cache.test.mjs
@@ -20,6 +20,8 @@ import {
 function makeFinalScorecard({
   teams,
   winner,
+  status = null,
+  omitScore = false,
   batter,
   bowler,
   catcher,
@@ -35,27 +37,60 @@ function makeFinalScorecard({
   return {
     teams,
     matchWinner: winner,
-    scorecard: [{
-      batting: [{
-        batsman: { name: batter },
-        r: runs,
-        b: balls,
-        '6s': sixes
-      }],
-      bowling: [{
-        bowler: { name: bowler },
-        o: overs,
-        w: wickets,
-        r: concededRuns
-      }],
-      catching: [{
-        catcher: { name: catcher },
-        catch: 1
-      }]
-    }],
-    score: [
-      { inning: `${teams[0]} Innings`, r: scoreA, w: 6, o: '20' },
-      { inning: `${teams[1]} Innings`, r: scoreB, w: 8, o: '20' }
+    status: status || (winner === 'No Winner' ? 'No result' : `${winner} won`),
+    scorecard: [
+      {
+        batting: [{
+          batsman: { name: batter },
+          r: runs,
+          b: balls,
+          '6s': sixes
+        }],
+        bowling: [
+          {
+            bowler: { name: bowler },
+            o: overs,
+            w: wickets,
+            r: concededRuns
+          },
+          {
+            bowler: { name: `${teams[1]} Support Bowler` },
+            o: '16',
+            w: Math.max(0, 6 - wickets),
+            r: Math.max(0, scoreA - concededRuns)
+          }
+        ],
+        catching: [{
+          catcher: { name: catcher },
+          catch: 1
+        }],
+        extras: {},
+        inning: `${teams[0]} Inning 1`
+      },
+      {
+        batting: [{
+          batsman: { name: `${teams[1]} Batter` },
+          r: scoreB,
+          b: Math.max(1, scoreB),
+          '6s': Math.max(0, Math.floor(scoreB / 30))
+        }],
+        bowling: [{
+          bowler: { name: `${teams[0]} Bowler` },
+          o: '20',
+          w: 8,
+          r: scoreB
+        }],
+        catching: [{
+          catcher: { name: `${teams[0]} Catcher` },
+          catch: 1
+        }],
+        extras: {},
+        inning: `${teams[1]} Inning 1`
+      }
+    ],
+    score: omitScore ? [] : [
+      { inning: `${teams[0]} Inning 1`, r: scoreA, w: 6, o: '20' },
+      { inning: `${teams[1]} Inning 1`, r: scoreB, w: 8, o: '20' }
     ]
   };
 }
@@ -298,4 +333,92 @@ test('repairs missing score-history checkpoints from the nearest earlier snapsho
   assert.equal(repaired.cacheHits, 0);
   assert.deepEqual(repairedCounts, [0, 1, 2]);
   assert.equal(repairedSnapshot.snapshot.meta.aggregates.battingRuns['Virat Kohli'], 88);
+});
+
+test('standings award one point each for no-result matches', async () => {
+  const rebuilt = await rebuildHistoricalState(
+    ['match-12'],
+    {
+      meta: {
+        scoreHistory: [{ processedMatchCount: 0, fetchedAt: '2026-04-01T00:00:00.000Z' }]
+      }
+    },
+    {
+      includeHistory: true,
+      loadScorecard: async () => ({
+        data: makeFinalScorecard({
+          teams: ['Kolkata Knight Riders', 'Punjab Kings'],
+          winner: 'No Winner',
+          status: 'No result (due to rain)',
+          batter: 'Venkatesh Iyer',
+          bowler: 'Arshdeep Singh',
+          catcher: 'Andre Russell',
+          runs: 25,
+          balls: 14,
+          sixes: 2,
+          wickets: 1,
+          concededRuns: 18,
+          overs: '3',
+          scoreA: 25,
+          scoreB: 0
+        }),
+        source: 'cache'
+      })
+    }
+  );
+
+  const kkr = rebuilt.aggregates.standings['Kolkata Knight Riders'];
+  const pbks = rebuilt.aggregates.standings['Punjab Kings'];
+
+  assert.equal(kkr.played, 1);
+  assert.equal(pbks.played, 1);
+  assert.equal(kkr.noResult, 1);
+  assert.equal(pbks.noResult, 1);
+  assert.equal(kkr.points, 1);
+  assert.equal(pbks.points, 1);
+});
+
+test('standings still update when scorecard omits the top-level score summary', async () => {
+  const rebuilt = await rebuildHistoricalState(
+    ['match-13'],
+    {
+      meta: {
+        scoreHistory: [{ processedMatchCount: 0, fetchedAt: '2026-04-01T00:00:00.000Z' }]
+      }
+    },
+    {
+      includeHistory: true,
+      loadScorecard: async () => ({
+        data: makeFinalScorecard({
+          teams: ['Rajasthan Royals', 'Mumbai Indians'],
+          winner: 'Rajasthan Royals',
+          status: 'Rajasthan Royals won by 3 wickets (match reduced to 18 overs due to rain)',
+          omitScore: true,
+          batter: 'Yashasvi Jaiswal',
+          bowler: 'Jasprit Bumrah',
+          catcher: 'Sanju Samson',
+          runs: 123,
+          balls: 90,
+          sixes: 7,
+          wickets: 2,
+          concededRuns: 24,
+          overs: '4',
+          scoreA: 123,
+          scoreB: 96
+        }),
+        source: 'cache'
+      })
+    }
+  );
+
+  const rr = rebuilt.aggregates.standings['Rajasthan Royals'];
+  const mi = rebuilt.aggregates.standings['Mumbai Indians'];
+
+  assert.equal(rr.played, 1);
+  assert.equal(rr.wins, 1);
+  assert.equal(rr.points, 2);
+  assert.equal(mi.played, 1);
+  assert.equal(mi.losses, 1);
+  assert.equal(rr.runsFor, 123);
+  assert.equal(mi.runsFor, 96);
 });


### PR DESCRIPTION
## Summary
- refresh joined duel labels and recover duel starts from submission timestamps
- repair live standings for washed-out and reduced matches
- prefer profile display names in the Mini Fantasy leaderboard
- resolve Mini Fantasy player-history aliases so pricing and stats pick up players like Mohammad Shami and M. Siddharth correctly
- keep the live-data workflow using the dedicated bot token for direct refresh pushes

## Verification
- `tests/page.smoke.spec.mjs`
- `tests/page.directory-wiring.test.mjs`
- `tests/mini-fantasy-contest-engine.test.mjs`
- `tests/mini-fantasy-pricing-engine.test.mjs`
- `tests/update-live-data.scorecard-cache.test.mjs`
- `tests/update-live-data.quota.test.mjs`

## Notes
- no Supabase schema change is required in this PR
- `data/mini_fantasy_prices.json` is regenerated with the alias fix included