### PR TITLE
[codex] tighten mini fantasy flow and scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,12 +615,6 @@
       box-shadow:0 18px 40px rgba(0,0,0,.22), inset 0 1px 0 rgba(255,255,255,.04);
     }
     .fantasy-builder-card .section-title{color:#d7fff1}
-    .fantasy-recap-card{
-      background:
-        radial-gradient(circle at top left, rgba(124,196,255,.16), transparent 44%),
-        linear-gradient(180deg, rgba(17,27,54,.96), rgba(8,15,32,.94));
-      border:1px solid rgba(124,196,255,.18);
-    }
     .fantasy-stage{display:grid;grid-template-columns:minmax(0,1.18fr) minmax(250px,.72fr);gap:16px;align-items:start}
     @media (max-width:1100px){.fantasy-stage{grid-template-columns:1fr}}
     .fantasy-viewer-card{
@@ -646,6 +640,33 @@
     .fantasy-headline{font-size:clamp(22px,3.2vw,32px);font-weight:900;line-height:1.06;color:#fff}
     .fantasy-sub{font-size:13px;color:var(--muted);line-height:1.55;max-width:860px}
     .fantasy-meta{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}
+    .fantasy-guide-card{
+      margin-top:16px;
+      padding:14px 16px;
+      border-radius:18px;
+      border:1px solid rgba(124,196,255,.16);
+      background:
+        radial-gradient(circle at top left, rgba(124,196,255,.14), transparent 36%),
+        linear-gradient(180deg, rgba(14,23,47,.96), rgba(8,15,32,.92));
+      display:grid;
+      gap:12px;
+    }
+    .fantasy-guide-top{display:flex;justify-content:space-between;gap:12px;align-items:flex-start;flex-wrap:wrap}
+    .fantasy-guide-copy{display:grid;gap:6px}
+    .fantasy-guide-title{font-size:14px;font-weight:900;letter-spacing:.04em;text-transform:uppercase;color:#e7f0ff}
+    .fantasy-guide-sub{font-size:12px;color:#bfd3f7;line-height:1.5;max-width:760px}
+    .fantasy-guide-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+    @media (max-width:760px){.fantasy-guide-grid{grid-template-columns:1fr}}
+    .fantasy-guide-note{
+      padding:11px 12px;
+      border-radius:14px;
+      border:1px solid rgba(124,196,255,.14);
+      background:rgba(124,196,255,.08);
+      font-size:12px;
+      color:#d9e7ff;
+      line-height:1.55;
+    }
+    .fantasy-guide-rules{display:flex;gap:8px;flex-wrap:wrap}
     .fantasy-fixture-list{display:grid;gap:14px}
     .fantasy-switcher-shell{display:grid;gap:12px}
     .fantasy-switcher-row{display:flex;gap:10px;flex-wrap:wrap}
@@ -933,6 +954,26 @@
             <div class="fantasy-headline" id="miniFantasyHeadline">Mini Fantasy opens from Match 14</div>
             <div class="fantasy-sub" id="miniFantasySummary">Pick a 4-player team for each eligible match, stay under 31 credits, lock one captain for a 1.5x boost, and get your entries saved match by match.</div>
             <div class="fantasy-meta" id="miniFantasyMeta"></div>
+            <div class="fantasy-guide-card">
+              <div class="fantasy-guide-top">
+                <div class="fantasy-guide-copy">
+                  <div class="fantasy-guide-title">How Mini Fantasy works</div>
+                  <div class="fantasy-guide-sub">Build only for open fixtures here. Once a match locks, the leaderboard becomes your window into everyone’s locked teams and live points.</div>
+                </div>
+              </div>
+              <div class="fantasy-guide-grid">
+                <div class="fantasy-guide-note">Use the fixture switcher to move between today and tomorrow’s open games, then save one 4-player team with a captain before lock.</div>
+                <div class="fantasy-guide-note">Click any user in the leaderboard to inspect their most recently locked team, see who missed lock, and follow live or final points.</div>
+              </div>
+              <div class="fantasy-guide-rules">
+                <div class="pill">Exactly 4 players</div>
+                <div class="pill">Budget: 31 credits</div>
+                <div class="pill">At least 1 player from each team</div>
+                <div class="pill">At least 1 batter</div>
+                <div class="pill">At least 1 bowler</div>
+                <div class="pill">Captain scores 1.5x</div>
+              </div>
+            </div>
           </div>
         </div>
         <div class="span-12 fantasy-layout">
@@ -941,24 +982,6 @@
               <div id="miniFantasyFixtures" class="fantasy-fixture-list"></div>
               <div class="section-title">Team builder</div>
               <div id="miniFantasyBuilder"></div>
-            </div>
-            <div class="card fantasy-recap-card">
-              <div class="section-title">Last game recap</div>
-              <div id="miniFantasyLastGame"></div>
-            </div>
-            <div class="card">
-              <div class="section-title">How Mini Fantasy works</div>
-              <div class="studio-note">The compact builder is always for open fixtures only. Use the fixture switcher to move between today and tomorrow's open matches.</div>
-              <div class="studio-note">Once a match locks, the leaderboard becomes the way to inspect locked teams. Click any user to view their picks, captain, and live or final points for the most recently locked fixture.</div>
-              <div class="studio-note">Your last-game recap stays on the left so you can compare what just happened while still building the next team.</div>
-              <div class="fantasy-rules">
-                <div class="pill">Exactly 4 players</div>
-                <div class="pill">Budget: 31 credits</div>
-                <div class="pill">At least 1 player from each team</div>
-                <div class="pill">At least 1 batter</div>
-                <div class="pill">At least 1 bowler</div>
-                <div class="pill">Captain scores 1.5x</div>
-              </div>
             </div>
           </div>
           <div class="fantasy-stage">
@@ -1119,7 +1142,9 @@
       getCompletedMiniFantasyMatchCount,
       getMiniFantasyFixtureAvailability,
       getMiniFantasyOpenFixtures,
+      getMiniFantasyWinningTeamCode,
       isFixtureLocked,
+      resolveMiniFantasyPlayerTeamCode,
       scoreMiniFantasyLineup,
       scoreMiniFantasyEntry,
       validateMiniFantasyEntry
@@ -7616,28 +7641,38 @@ function titleBandScore(pick, live){
       return Number.isInteger(amount) ? String(amount) : amount.toFixed(1);
     }
 
-    function describeMiniFantasyEntry(entry, fixturePointsIndex = new Map()){
-      if (!entry) {
-        return {
-          totalPoints: 0,
-          pointsByPlayerId: {},
+      function describeMiniFantasyEntry(entry, fixturePointsIndex = new Map()){
+        if (!entry) {
+          return {
+            totalPoints: 0,
+            pointsByPlayerId: {},
           players: [],
           captain: null,
           bestPick: null,
           summary: 'No team was locked for this fixture.'
         };
       }
-      const playerPool = miniFantasyEntryPlayerPool(entry);
-      const poolById = new Map(playerPool.map((player) => [player.player_id, player]));
-      const selectedPlayerIds = Array.isArray(entry.selectedPlayerIds) ? entry.selectedPlayerIds.filter(Boolean) : [];
-      const pointsByPlayerId = Object.fromEntries(selectedPlayerIds.map((playerId) => [playerId, Number(fixturePointsIndex.get(playerId) || 0)]));
-      const totalPoints = scoreMiniFantasyLineup({
-        selectedPlayerIds,
-        captainPlayerId: entry.captainPlayerId || '',
-        pointsByPlayerId
-      });
-      const players = selectedPlayerIds.map((playerId) => {
-        const player = poolById.get(playerId) || null;
+        const playerPool = miniFantasyEntryPlayerPool(entry);
+        const poolById = new Map(playerPool.map((player) => [player.player_id, player]));
+        const selectedPlayerIds = Array.isArray(entry.selectedPlayerIds) ? entry.selectedPlayerIds.filter(Boolean) : [];
+        const pointsByPlayerId = Object.fromEntries(selectedPlayerIds.map((playerId) => [playerId, Number(fixturePointsIndex.get(playerId) || 0)]));
+        const playerTeamById = Object.fromEntries(selectedPlayerIds.map((playerId) => [playerId, (poolById.get(playerId)?.team || resolveMiniFantasyPlayerTeamCode(playerId))]));
+        const winningTeamCode = getMiniFantasyWinningTeamCode({
+          liveData: LIVE_2026,
+          schedule: LEAGUE_STAGE_SCHEDULE,
+          matchNo: entry.matchNo
+        });
+        const fixture = miniFantasyFixtureByMatchNo(entry.matchNo);
+        const isCompletedFixture = fixture ? Number(entry.matchNo || 0) <= getCompletedMiniFantasyMatchCount(LIVE_2026) : false;
+        const totalPoints = scoreMiniFantasyLineup({
+          selectedPlayerIds,
+          captainPlayerId: entry.captainPlayerId || '',
+          pointsByPlayerId,
+          playerTeamById,
+          winningTeamCode: isCompletedFixture ? winningTeamCode : ''
+        });
+        const players = selectedPlayerIds.map((playerId) => {
+          const player = poolById.get(playerId) || null;
         return {
           playerId,
           name: player?.name || fallbackMiniFantasyPlayerName(playerId),

--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -21,6 +21,7 @@ export const MINI_FANTASY_FIRST_MATCH_OPEN_AT_UTC = '2026-04-06T00:00:00Z';
 export const MINI_FANTASY_TEAM_SIZE = 4;
 export const MINI_FANTASY_BUDGET = 31;
 export const MINI_FANTASY_CAPTAIN_MULTIPLIER = 1.5;
+export const MINI_FANTASY_WINNING_TEAM_PLAYER_BONUS = 5;
 export const MINI_FANTASY_LOCK_OFFSET_MINUTES = 1;
 
 export const TEAM_CODE_TO_NAME = Object.freeze({
@@ -181,6 +182,11 @@ export function slugify(value) {
 
 export function buildMiniFantasyPlayerId(teamCode, playerName) {
   return `${String(teamCode || '').toLowerCase()}_${slugify(playerName)}`;
+}
+
+export function resolveMiniFantasyPlayerTeamCode(playerId = '') {
+  const teamCode = String(playerId || '').split('_')[0].toUpperCase();
+  return TEAM_CODE_TO_NAME[teamCode] ? teamCode : '';
 }
 
 export function currentRoleOverride(teamCode, playerName) {
@@ -786,7 +792,10 @@ export function validateMiniFantasyEntry({
 export function scoreMiniFantasyLineup({
   selectedPlayerIds = [],
   captainPlayerId = '',
-  pointsByPlayerId = {}
+  pointsByPlayerId = {},
+  playerTeamById = {},
+  winningTeamCode = '',
+  winningPlayerBonus = MINI_FANTASY_WINNING_TEAM_PLAYER_BONUS
 } = {}) {
   const selected = [...new Set((Array.isArray(selectedPlayerIds) ? selectedPlayerIds : []).filter(Boolean))];
   let total = 0;
@@ -794,6 +803,12 @@ export function scoreMiniFantasyLineup({
     const rawPoints = toNumber(pointsByPlayerId[playerId], 0);
     const multiplier = playerId === captainPlayerId ? MINI_FANTASY_CAPTAIN_MULTIPLIER : 1;
     total += rawPoints * multiplier;
+  });
+  total += calculateMiniFantasyWinningTeamBonus({
+    selectedPlayerIds: selected,
+    playerTeamById,
+    winningTeamCode,
+    winningPlayerBonus
   });
   return roundTo(total, 2);
 }
@@ -911,6 +926,60 @@ export function buildMiniFantasyFixturePointsIndex({
   return pointsIndex;
 }
 
+function cachedMiniFantasyMatchList(liveData = {}) {
+  return Array.isArray(liveData?.meta?.cache?.matchList) ? liveData.meta.cache.matchList : [];
+}
+
+export function getMiniFantasyWinningTeamCode({
+  liveData = {},
+  schedule = [],
+  matchNo = null
+} = {}) {
+  const targetMatchNo = Number(matchNo || 0) || null;
+  if (!targetMatchNo) return '';
+
+  const cachedMatch = cachedMiniFantasyMatchList(liveData).find((match) => Number(match?.matchNo || 0) === targetMatchNo) || null;
+  const fixture = (Array.isArray(schedule) ? schedule : []).find((item) => Number(item?.match_no || 0) === targetMatchNo) || null;
+  const status = normalizeWhitespace(cachedMatch?.status || '');
+  if (!status || /^match starts\b/i.test(status) || /^live\b/i.test(status)) return '';
+  if (/no result|abandoned|tied|tie\b/i.test(status)) return '';
+
+  const candidateTeams = [
+    ...(Array.isArray(cachedMatch?.teams) ? cachedMatch.teams : []),
+    fixture?.home_team,
+    fixture?.away_team
+  ]
+    .map((team) => normalizeWhitespace(team))
+    .filter(Boolean);
+
+  const lowerStatus = status.toLowerCase();
+  const matchedTeam = [...new Set(candidateTeams)]
+    .sort((a, b) => b.length - a.length)
+    .find((team) => lowerStatus.includes(team.toLowerCase()));
+
+  return resolveFixtureTeamCode(matchedTeam || '');
+}
+
+function calculateMiniFantasyWinningTeamBonus({
+  selectedPlayerIds = [],
+  playerTeamById = {},
+  winningTeamCode = '',
+  winningPlayerBonus = MINI_FANTASY_WINNING_TEAM_PLAYER_BONUS
+} = {}) {
+  const resolvedWinningTeamCode = resolveFixtureTeamCode(winningTeamCode);
+  const bonusPerPlayer = toNumber(winningPlayerBonus, 0);
+  if (!resolvedWinningTeamCode || bonusPerPlayer <= 0) return 0;
+
+  return roundTo(
+    [...new Set((Array.isArray(selectedPlayerIds) ? selectedPlayerIds : []).filter(Boolean))]
+      .reduce((total, playerId) => {
+        const playerTeamCode = resolveFixtureTeamCode(playerTeamById[playerId] || resolveMiniFantasyPlayerTeamCode(playerId));
+        return total + (playerTeamCode === resolvedWinningTeamCode ? bonusPerPlayer : 0);
+      }, 0),
+    2
+  );
+}
+
 export function scoreMiniFantasyEntry({
   entry = {},
   liveData = {},
@@ -920,24 +989,37 @@ export function scoreMiniFantasyEntry({
   const matchNo = Number(entry?.matchNo || entry?.match_no || 0) || null;
   const completedMatchCount = getCompletedMiniFantasyMatchCount(liveData);
   const pointsIndex = buildMiniFantasyPlayerPointsIndex({ liveData, schedule, squads });
+  const selectedPlayerIds = Array.isArray(entry?.selectedPlayerIds) ? entry.selectedPlayerIds : [];
   const pointsByPlayerId = Object.fromEntries(
-    (Array.isArray(entry?.selectedPlayerIds) ? entry.selectedPlayerIds : []).map((playerId) => [
+    selectedPlayerIds.map((playerId) => [
       playerId,
       pointsIndex.get(playerId)?.points_by_match_no?.[matchNo] || 0
     ])
   );
+  const playerTeamById = Object.fromEntries(selectedPlayerIds.map((playerId) => [playerId, resolveMiniFantasyPlayerTeamCode(playerId)]));
+  const winningTeamCode = matchNo && matchNo <= completedMatchCount
+    ? getMiniFantasyWinningTeamCode({ liveData, schedule, matchNo })
+    : '';
   const totalPoints = matchNo && matchNo <= completedMatchCount
     ? scoreMiniFantasyLineup({
-        selectedPlayerIds: entry?.selectedPlayerIds || [],
+        selectedPlayerIds,
         captainPlayerId: entry?.captainPlayerId || '',
-        pointsByPlayerId
+        pointsByPlayerId,
+        playerTeamById,
+        winningTeamCode
       })
     : 0;
   return {
     match_no: matchNo,
     is_scored: Boolean(matchNo && matchNo <= completedMatchCount),
     total_points: totalPoints,
-    points_by_player_id: pointsByPlayerId
+    points_by_player_id: pointsByPlayerId,
+    winning_team_code: winningTeamCode || null,
+    winner_bonus_points: calculateMiniFantasyWinningTeamBonus({
+      selectedPlayerIds,
+      playerTeamById,
+      winningTeamCode
+    })
   };
 }
 
@@ -956,18 +1038,25 @@ export function buildMiniFantasyLeaderboard({
     const displayName = normalizeWhitespace(entry?.displayName || entry?.display_name || ownerHandle || '');
     if (!ownerHandle) return;
     const matchNo = Number(entry?.matchNo || entry?.match_no || 0) || null;
+    const selectedPlayerIds = entry?.selectedPlayerIds || entry?.selected_player_ids || [];
     const pointsByPlayerId = Object.fromEntries(
-      (Array.isArray(entry?.selectedPlayerIds || entry?.selected_player_ids) ? (entry.selectedPlayerIds || entry.selected_player_ids) : []).map((playerId) => [
+      (Array.isArray(selectedPlayerIds) ? selectedPlayerIds : []).map((playerId) => [
         playerId,
         pointsIndex.get(playerId)?.points_by_match_no?.[matchNo] || 0
       ])
     );
     const scored = Boolean(matchNo && matchNo <= completedMatchCount);
+    const playerTeamById = Object.fromEntries(
+      (Array.isArray(selectedPlayerIds) ? selectedPlayerIds : []).map((playerId) => [playerId, resolveMiniFantasyPlayerTeamCode(playerId)])
+    );
+    const winningTeamCode = scored ? getMiniFantasyWinningTeamCode({ liveData, schedule, matchNo }) : '';
     const totalPoints = scored
       ? scoreMiniFantasyLineup({
-          selectedPlayerIds: entry?.selectedPlayerIds || entry?.selected_player_ids || [],
+          selectedPlayerIds,
           captainPlayerId: entry?.captainPlayerId || entry?.captain_player_id || '',
-          pointsByPlayerId
+          pointsByPlayerId,
+          playerTeamById,
+          winningTeamCode
         })
       : 0;
     const existing = grouped.get(ownerHandle) || {

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -11,6 +11,7 @@ import {
   generateMiniFantasyPriceBook,
   getMiniFantasyOpenFixtures,
   resolvePlayerHistory,
+  scoreMiniFantasyEntry,
   validateMiniFantasyEntry
 } from '../mini-fantasy/contest-engine.js';
 
@@ -477,6 +478,15 @@ test('generateMiniFantasyPriceBook keeps alias-matched LSG bowlers from falling 
 test('buildMiniFantasyLeaderboard ranks saved users by scored mini fantasy points', () => {
   const liveData = {
     meta: {
+      cache: {
+        matchList: [
+          {
+            matchNo: 14,
+            status: 'Delhi Capitals won by 6 wkts',
+            teams: ['Delhi Capitals', 'Gujarat Titans']
+          }
+        ]
+      },
       scoreHistory: [
         {
           processedMatchCount: 14,
@@ -549,6 +559,97 @@ test('buildMiniFantasyLeaderboard ranks saved users by scored mini fantasy point
   assert.equal(leaderboard.rows[0].display_name, 'Senthil');
   assert.equal(leaderboard.rows[0].medal, 'gold');
   assert.equal(leaderboard.rows[1].medal, 'silver');
-  assert.equal(leaderboard.rows[0].total_points, 102);
-  assert.equal(leaderboard.rows[1].total_points, 88);
+  assert.equal(leaderboard.rows[0].total_points, 112);
+  assert.equal(leaderboard.rows[1].total_points, 98);
+});
+
+test('scoreMiniFantasyEntry adds +5 for each selected player from the winning side and skips no-result bonus', () => {
+  const entry = {
+    matchNo: 14,
+    selectedPlayerIds: [
+      buildMiniFantasyPlayerId('DC', 'DC Batter'),
+      buildMiniFantasyPlayerId('DC', 'DC Bowler'),
+      buildMiniFantasyPlayerId('GT', 'GT Bowler'),
+      buildMiniFantasyPlayerId('GT', 'GT Keeper')
+    ],
+    captainPlayerId: buildMiniFantasyPlayerId('DC', 'DC Batter')
+  };
+  const schedule = [
+    { match_no: 14, datetime_utc: '2026-04-08T14:00:00Z', home_team: 'Delhi Capitals', away_team: 'Gujarat Titans' }
+  ];
+  const squads = {
+    DC: ['DC Batter', 'DC Bowler'],
+    GT: ['GT Bowler', 'GT Keeper']
+  };
+  const scoredLiveData = {
+    meta: {
+      cache: {
+        matchList: [
+          {
+            matchNo: 14,
+            status: 'Delhi Capitals won by 6 wkts',
+            teams: ['Delhi Capitals', 'Gujarat Titans']
+          }
+        ]
+      },
+      scoreHistory: [
+        {
+          processedMatchCount: 14,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'DC Batter': 1,
+                  'DC Bowler': 1,
+                  'GT Bowler': 1,
+                  'GT Keeper': 1
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'DC Batter': { score: 40 },
+                'DC Bowler': { score: 20 },
+                'GT Bowler': { score: 10 },
+                'GT Keeper': { score: 12 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  };
+
+  const scored = scoreMiniFantasyEntry({
+    entry,
+    liveData: scoredLiveData,
+    schedule,
+    squads
+  });
+  assert.equal(scored.total_points, 112);
+  assert.equal(scored.winner_bonus_points, 10);
+  assert.equal(scored.winning_team_code, 'DC');
+
+  const noResult = scoreMiniFantasyEntry({
+    entry,
+    liveData: {
+      meta: {
+        cache: {
+          matchList: [
+            {
+              matchNo: 14,
+              status: 'No result (due to rain)',
+              teams: ['Delhi Capitals', 'Gujarat Titans']
+            }
+          ]
+        },
+        scoreHistory: scoredLiveData.meta.scoreHistory
+      }
+    },
+    schedule,
+    squads
+  });
+  assert.equal(noResult.total_points, 102);
+  assert.equal(noResult.winner_bonus_points, 0);
+  assert.equal(noResult.winning_team_code, null);
 });

--- a/tests/page.directory-wiring.test.mjs
+++ b/tests/page.directory-wiring.test.mjs
@@ -17,7 +17,6 @@ test('public duel directory wiring exists in the page shell', async () => {
   assert.match(html, /id="miniFantasyFixtures"/);
   assert.match(html, /id="miniFantasyBuilder"/);
   assert.match(html, /id="miniFantasyLeaderboard"/);
-  assert.match(html, /id="miniFantasyLastGame"/);
   assert.match(html, /id="miniFantasyLockedViewer"/);
   assert.match(html, /id="miniFantasyPickerModal"/);
   assert.match(html, /id="authPanel"/);

--- a/tests/page.smoke.spec.mjs
+++ b/tests/page.smoke.spec.mjs
@@ -268,7 +268,6 @@ test('mini fantasy opens Match 14 early, shows future submit windows, and ranks 
   await page.locator('#saveMiniFantasyButton').click();
 
   await expect(page.locator('#miniFantasyBuilder')).toContainText('team saved');
-  await expect(page.locator('#miniFantasyLastGame')).toContainText('already have a saved team for it');
   await expect(page.locator('#miniFantasyLeaderboard')).toContainText('Mini Bala');
   await expect(page.locator('#miniFantasyLeaderboard')).toContainText('@mini-bala');
   await expect(page.locator('#miniFantasyLeaderboard')).toContainText(/medal/i);


### PR DESCRIPTION
## Summary
- tighten the Mini Fantasy page by removing the last-game recap and moving a compact rules guide into the top header area
- add the +5 winning-team bonus for each selected player once a fixture result is final, while keeping no-result fixtures neutral
- keep the recent locked-team viewer and tests aligned with the compact Mini Fantasy flow

## Testing
- tests/mini-fantasy-contest-engine.test.mjs
- tests/page.directory-wiring.test.mjs
- tests/page.smoke.spec.mjs