### PR TITLE
fix(ui): global leaderboard scroll, picker role filters, modal centering, auth toast flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1039,6 +1039,8 @@
       </div>
     </div>
 
+    <div id="toastBanner" class="toast-banner toast-hidden" role="status" aria-live="polite" aria-atomic="true"></div>
+
     <div id="surfaceBackdrop" class="surface-backdrop section-hidden"></div>
 
     <aside id="profileDrawer" class="surface-drawer section-hidden" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -376,6 +376,39 @@
     .studio-invite-code{display:inline-flex;align-items:center;gap:8px;max-width:100%;padding:10px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.12);background:rgba(7,12,24,.38);font-size:16px;font-weight:900;color:#fff;overflow-wrap:anywhere;word-break:break-word}
     .studio-invite-actions{display:flex;gap:10px;flex-wrap:wrap}
     .studio-callout{padding:12px 14px;border-radius:14px;border:1px solid var(--info-line);background:linear-gradient(180deg, rgba(124,196,255,.14), rgba(18,31,66,.82));font-size:13px;line-height:1.55;color:#eff7ff}
+    .toast-banner{
+      position:fixed;
+      top:20px;
+      left:50%;
+      transform:translateX(-50%) translateY(0);
+      z-index:300;
+      min-width:280px;
+      max-width:min(560px,90vw);
+      padding:14px 20px;
+      border-radius:14px;
+      font-size:13px;
+      font-weight:700;
+      line-height:1.5;
+      text-align:center;
+      box-shadow:0 8px 32px rgba(0,0,0,.45);
+      transition:opacity .22s ease, transform .22s ease;
+      pointer-events:auto;
+    }
+    .toast-banner.toast-good{
+      background:linear-gradient(180deg,rgba(68,215,146,.22),rgba(20,60,40,.96));
+      border:1px solid rgba(68,215,146,.34);
+      color:#b8f5d4;
+    }
+    .toast-banner.toast-bad{
+      background:linear-gradient(180deg,rgba(255,90,120,.22),rgba(50,16,22,.96));
+      border:1px solid rgba(255,90,120,.34);
+      color:#ffc4ce;
+    }
+    .toast-banner.toast-hidden{
+      opacity:0;
+      transform:translateX(-50%) translateY(-12px);
+      pointer-events:none;
+    }
     .surface-backdrop{
       position:fixed;
       inset:0;
@@ -423,7 +456,7 @@
       inset:0;
       z-index:120;
       display:flex;
-      align-items:flex-end;
+      align-items:center;
       justify-content:center;
       padding:18px;
       background:rgba(4,9,18,.70);
@@ -1109,7 +1142,7 @@
           <button class="picker-close" id="miniFantasyPickerClose" type="button">Close picker</button>
         </div>
         <div class="picker-toolbar" id="miniFantasyPickerToolbar"></div>
-        <div id="miniFantasyPickerBody"></div>
+        <div id="miniFantasyPickerBody"  style="margin-top:16px"></div>
         <div class="picker-footer">
           <div class="picker-count" id="miniFantasyPickerCount">0 options</div>
           <div class="studio-inline">
@@ -1176,6 +1209,19 @@
     let HOSTED_AUTH_MODE = 'signin';
     let AUTH_FORM_PREFILL = { displayName: '', ownerId: '', email: '' };
     let AUTH_PANEL_NOTICE = null;
+    let _toastTimer = null;
+
+    function showToast(type, text, durationMs = 5000){
+      const el = document.getElementById('toastBanner');
+      if (!el) return;
+      if (_toastTimer) { clearTimeout(_toastTimer); _toastTimer = null; }
+      el.className = `toast-banner toast-${type === 'good' ? 'good' : 'bad'}`;
+      el.textContent = text;
+      _toastTimer = setTimeout(() => {
+        el.classList.add('toast-hidden');
+        _toastTimer = null;
+      }, durationMs);
+    }
     let CUSTOM_DUEL_STORE = { version: 1, rooms: {} };
     let REMOTE_DUEL_STORE = { version: 1, rooms: {} };
     let REMOTE_MINI_FANTASY_ENTRIES = [];
@@ -1194,6 +1240,7 @@
       matchNo: null,
       slotIndex: null,
       teamFilter: 'ALL',
+      roleFilter: 'ALL',
       search: '',
       restoreSearchFocus: false,
       searchSelectionStart: null,
@@ -5486,7 +5533,7 @@ function titleBandScore(pick, live){
                   text: 'Your account is ready. Sign in now with the same email + password.',
                   nextStep: 'Use only email + password in Sign in. Display name and handle are already saved.'
                 });
-                setStudioNotice('info', 'Account created. Sign in now with the same email + password.');
+                showToast('good', 'Account created. Sign in now with the same email + password.');
                 await syncMiniFantasyEntries();
                 render();
                 return;
@@ -5494,7 +5541,7 @@ function titleBandScore(pick, live){
               CURRENT_USER = normalizeUserProfile(remoteUser || {}) || null;
               if (!CURRENT_USER) {
                 setAuthPanelNotice('bad', 'Your account exists, but the profile could not load yet. Please try signing in again.');
-                setStudioNotice('bad', 'The hosted account signed in, but the Duels profile is incomplete.');
+                showToast('bad', 'Profile could not load. Please try signing in again.');
                 render();
                 return;
               }
@@ -5504,12 +5551,13 @@ function titleBandScore(pick, live){
                 ownerId: CURRENT_USER.ownerId,
                 email: CURRENT_USER.email || formData.get('email') || AUTH_FORM_PREFILL.email || ''
               });
-              setStudioNotice('good', `Signed in as ${CURRENT_USER.displayName}. Your Duels and Mini Fantasy account is ready in this browser.`);
+              setActiveDrawer(null);
+              showToast('good', `Signed in as ${CURRENT_USER.displayName}. Your Duels and Mini Fantasy account is ready.`);
               await syncMiniFantasyEntries();
             } catch (error) {
               const friendlyError = friendlyHostedAuthError(action, error);
               setAuthPanelNotice('bad', friendlyError);
-              setStudioNotice('bad', friendlyError);
+              showToast('bad', typeof friendlyError === 'string' ? friendlyError : (friendlyError.text || 'Sign in failed. Please try again.'));
             }
             render();
             return;
@@ -5525,7 +5573,8 @@ function titleBandScore(pick, live){
             return;
           }
           setAuthPanelNotice(null);
-          setStudioNotice('good', `Signed in as ${saved.displayName}. You can now create, join, and submit public duels from this browser.`);
+          setActiveDrawer(null);
+          showToast('good', `Signed in as ${saved.displayName}. You can now create, join, and submit public duels from this browser.`);
           await syncMiniFantasyEntries();
           render();
         };
@@ -7868,6 +7917,7 @@ function titleBandScore(pick, live){
         matchNo: Number(matchNo),
         slotIndex: Number(slotIndex),
         teamFilter: 'ALL',
+        roleFilter: 'ALL',
         search: '',
         restoreSearchFocus: true,
         searchSelectionStart: null,
@@ -7882,6 +7932,7 @@ function titleBandScore(pick, live){
         matchNo: null,
         slotIndex: null,
         teamFilter: 'ALL',
+        roleFilter: 'ALL',
         search: '',
         restoreSearchFocus: false,
         searchSelectionStart: null,
@@ -7900,6 +7951,7 @@ function titleBandScore(pick, live){
       return currentMiniFantasyPlayerPool(fixture)
         .filter((player) => !otherSelected.has(player.player_id))
         .filter((player) => MINI_FANTASY_PICKER_STATE.teamFilter === 'ALL' || player.team === MINI_FANTASY_PICKER_STATE.teamFilter)
+        .filter((player) => MINI_FANTASY_PICKER_STATE.roleFilter === 'ALL' || player.role === MINI_FANTASY_PICKER_STATE.roleFilter)
         .filter((player) => {
           const needle = normalizeName(MINI_FANTASY_PICKER_STATE.search || '');
           if (!needle) return true;
@@ -8269,7 +8321,11 @@ function titleBandScore(pick, live){
       panel.querySelectorAll('[data-mini-leaderboard-owner]').forEach((button) => {
         button.onclick = () => {
           MINI_FANTASY_RECENT_OWNER_HANDLE = normalizeOwnerId(button.dataset.miniLeaderboardOwner || '');
+          const scrollEl = panel.querySelector('.fantasy-leaderboard-scroll');
+          const savedScroll = scrollEl ? scrollEl.scrollTop : 0;
           renderMiniFantasyLeaderboard();
+          const scrollElAfter = panel.querySelector('.fantasy-leaderboard-scroll');
+          if (scrollElAfter) scrollElAfter.scrollTop = savedScroll;
           renderMiniFantasyLockedViewer();
         };
       });
@@ -8591,6 +8647,13 @@ function titleBandScore(pick, live){
           <button type="button" class="picker-chip ${MINI_FANTASY_PICKER_STATE.teamFilter === fixture.home_team_code ? 'active' : ''}" data-mini-picker-team="${fixture.home_team_code}">${fixture.home_team_code}</button>
           <button type="button" class="picker-chip ${MINI_FANTASY_PICKER_STATE.teamFilter === fixture.away_team_code ? 'active' : ''}" data-mini-picker-team="${fixture.away_team_code}">${fixture.away_team_code}</button>
         </div>
+        <div class="picker-chip-row">
+          <button type="button" class="picker-chip ${MINI_FANTASY_PICKER_STATE.roleFilter === 'ALL' ? 'active' : ''}" data-mini-picker-role="ALL">All roles</button>
+          <button type="button" class="picker-chip ${MINI_FANTASY_PICKER_STATE.roleFilter === 'batter' ? 'active' : ''}" data-mini-picker-role="batter">Batter</button>
+          <button type="button" class="picker-chip ${MINI_FANTASY_PICKER_STATE.roleFilter === 'bowler' ? 'active' : ''}" data-mini-picker-role="bowler">Bowler</button>
+          <button type="button" class="picker-chip ${MINI_FANTASY_PICKER_STATE.roleFilter === 'all_rounder' ? 'active' : ''}" data-mini-picker-role="all_rounder">All rounder</button>
+          <button type="button" class="picker-chip ${MINI_FANTASY_PICKER_STATE.roleFilter === 'wicket_keeper' ? 'active' : ''}" data-mini-picker-role="wicket_keeper">Wicket keeper</button>
+        </div>
       `;
       body.innerHTML = filtered.length
         ? `<div class="fantasy-picker-list">
@@ -8620,6 +8683,12 @@ function titleBandScore(pick, live){
       toolbar.querySelectorAll('[data-mini-picker-team]').forEach((button) => {
         button.onclick = () => {
           MINI_FANTASY_PICKER_STATE.teamFilter = button.dataset.miniPickerTeam || 'ALL';
+          renderMiniFantasyPicker();
+        };
+      });
+      toolbar.querySelectorAll('[data-mini-picker-role]').forEach((button) => {
+        button.onclick = () => {
+          MINI_FANTASY_PICKER_STATE.roleFilter = button.dataset.miniPickerRole || 'ALL';
           renderMiniFantasyPicker();
         };
       });

--- a/tests/page.directory-wiring.test.mjs
+++ b/tests/page.directory-wiring.test.mjs
@@ -19,6 +19,7 @@ test('public duel directory wiring exists in the page shell', async () => {
   assert.match(html, /id="miniFantasyLeaderboard"/);
   assert.match(html, /id="miniFantasyLockedViewer"/);
   assert.match(html, /id="miniFantasyPickerModal"/);
+  assert.match(html, /id="toastBanner"/);
   assert.match(html, /id="authPanel"/);
   assert.match(html, /id="profilePanel"/);
   assert.match(html, /id="createDuelPanel"/);
@@ -81,6 +82,9 @@ test('public duel directory wiring exists in the page shell', async () => {
   assert.match(html, /data-directory-filter=/);
   assert.match(html, /data-mini-fixture=/);
   assert.match(html, /data-mini-pick=/);
+  assert.match(html, /data-mini-picker-role=/);
   assert.match(html, /data-mini-picker-value=/);
+  assert.match(html, /const savedScroll = scrollEl \? scrollEl\.scrollTop : 0/);
+  assert.match(html, /scrollElAfter\) scrollElAfter\.scrollTop = savedScroll/);
   assert.match(html, /window\.history\.replaceState/);
 });

--- a/tests/page.smoke.spec.mjs
+++ b/tests/page.smoke.spec.mjs
@@ -246,6 +246,10 @@ test('mini fantasy opens Match 14 early, shows future submit windows, and ranks 
 
   await page.locator('[data-mini-pick="0"]').click();
   await expect(page.locator('#miniFantasyPickerModal')).toBeVisible();
+  await page.locator('[data-mini-picker-role="bowler"]').click();
+  await page.locator('#miniFantasyPickerSearch').fill('duckett');
+  await expect(page.locator('#miniFantasyPickerBody')).toContainText('No player matches the current search and team filter.');
+  await page.locator('[data-mini-picker-role="ALL"]').click();
   await page.locator('#miniFantasyPickerSearch').fill('duckett');
   await page.locator('[data-mini-picker-value="dc_ben-duckett"]').click();
 

--- a/tests/page.smoke.spec.mjs
+++ b/tests/page.smoke.spec.mjs
@@ -71,15 +71,15 @@ test('duels beta supports picker search, clash resolution, and armed start gatin
   await page.locator('#authForm button[type="submit"]').click();
   await expect(page.locator('#myDuelsPanel')).toContainText('Senthil vs Sai');
   await expect(page.locator('#myDuelsPanel')).toContainText('Live from Match 1');
+  await page.locator('#profileChipButton').click();
+  await expect(page.locator('#profileDrawer')).toBeVisible();
   await page.locator('#authPanel').getByRole('button', { name: 'Sign out' }).click();
 
   await page.locator('#authDisplayName').fill('Anand');
   await page.locator('#authOwnerId').fill('anand');
   await page.locator('#authForm button[type="submit"]').click();
-  await expect(page.locator('#authPanel')).toContainText('Signed in as Anand');
-  await expect(page.locator('#profilePanel')).toContainText('Anand');
+  await expect(page.locator('#profileChipButton')).toContainText('Anand');
   await expect(page.locator('#myDuelsPanel')).toContainText('No duels yet');
-  await page.locator('#profileDrawer [data-close-drawer="profile"]').click();
   await page.locator('#createDuelButton').click();
   await expect(page.locator('#createDrawer')).toBeVisible();
   await expect(page.locator('#createDuelPanel')).toContainText('How Duel works');
@@ -134,7 +134,7 @@ test('duels beta supports picker search, clash resolution, and armed start gatin
   await page.locator('#authDisplayName').fill('Bala');
   await page.locator('#authOwnerId').fill('bala');
   await page.locator('#authForm button[type="submit"]').click();
-  await page.locator('#profileDrawer [data-close-drawer="profile"]').click();
+  await expect(page.locator('#profileChipButton')).toContainText('Bala');
   await page.locator('#createDuelButton').click();
   await page.locator('#joinByCodeInput').fill(duelCode);
   await page.getByRole('button', { name: 'Join by code' }).click();
@@ -227,7 +227,7 @@ test('mini fantasy opens Match 14 early, shows future submit windows, and ranks 
   await page.locator('#authDisplayName').fill('Mini Bala');
   await page.locator('#authOwnerId').fill('mini-bala');
   await page.locator('#authForm button[type="submit"]').click();
-  await page.locator('#profileDrawer [data-close-drawer="profile"]').click();
+  await expect(page.locator('#profileChipButton')).toContainText('Mini Bala');
 
   await expect(page.locator('#leagueTitle')).toContainText('SP Cup 2026 Mini Fantasy');
   await expect(page.getByRole('button', { name: 'Duel', exact: true })).toBeVisible();


### PR DESCRIPTION
### Summary

- fix global leaderboard rail jumping back to the top when clicking a user to view their locked team — scroll position is now preserved across re-renders
- add role filter chips (All roles / Batter / Bowler / All rounder / Wicket keeper) to the Mini Fantasy player picker modal so users can filter by role independently of the existing team chips
- center the player picker modal vertically — it was previously anchored to the bottom of the viewport via align-items: flex-end
- add 16px gap between the role filter chip row and the player card list in the picker modal
- introduce a fixed top-center toast notification system (z-index 300, green/red variants, auto-dismisses after 5 s) for sign-in feedback
- close the profile drawer automatically on successful sign-in and show a success toast instead of writing to the studio notice bar
- keep the profile drawer open on sign-in failure and surface a red toast at the top so the error is clearly visible regardless of drawer state
- replace setStudioNotice calls in the account-created and profile-incomplete paths with showToast for consistent top-of-screen feedback
- update smoke tests to remove explicit close-drawer clicks after sign-in (drawer now closes automatically), re-open drawer before Sign out, and assert sign-in success via the profile chip button label

### Testing
- tests/page.smoke.spec.mjs
- tests/duels-backend.wiring.test.mjs
- tests/league-model.test.mjs
- tests/live-data.contract.test.mjs