### PR TITLE
feat: Add locked fixture archive selector for mini fantasy

### DIFF
--- a/index.html
+++ b/index.html
@@ -8666,7 +8666,7 @@ function titleBandScore(pick, live){
           </div>
           <div class="fantasy-window-note">${escapeHtml(detailNote)}</div>
           ${selectedRow.fixtureStatus === 'did_not_lock'
-            ? '<div class="fantasy-empty">No locked team exists for this user on the most recently locked fixture.</div>'
+            ? '<div class="fantasy-empty">No locked team exists for this user on the selected fixture.</div>'
             : `
               <div class="fantasy-entry-player-list">
                 ${detailPlayers.map((player) => `
@@ -8826,7 +8826,7 @@ function titleBandScore(pick, live){
             </div>
           </div>
           ${selectedRow.fixtureStatus === 'did_not_lock'
-            ? '<div class="fantasy-empty">No locked team exists for this user on the most recently locked fixture.</div>'
+            ? '<div class="fantasy-empty">No locked team exists for this user on the selected fixture.</div>'
             : `
               <div class="fantasy-entry-player-list">
                 ${detailPlayers.map((player) => `

--- a/index.html
+++ b/index.html
@@ -752,6 +752,62 @@
     .fantasy-switcher-meta{display:flex;gap:8px;flex-wrap:wrap}
     .fantasy-switcher-meta .pill{background:rgba(255,255,255,.05);border-color:rgba(95,240,200,.16)}
     .fantasy-switcher-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(158px,1fr));gap:10px}
+    .fantasy-history-shell{
+      display:grid;
+      gap:12px;
+      padding:14px;
+      border-radius:18px;
+      border:1px solid rgba(255,200,87,.18);
+      background:linear-gradient(180deg, rgba(92,62,20,.26), rgba(21,12,19,.9));
+    }
+    .fantasy-history-head{display:flex;justify-content:space-between;gap:12px;align-items:flex-start;flex-wrap:wrap}
+    .fantasy-history-copy{display:grid;gap:6px;max-width:760px}
+    .fantasy-history-title{font-size:13px;font-weight:900;letter-spacing:.06em;text-transform:uppercase;color:#ffd67e}
+    .fantasy-history-sub{font-size:12px;line-height:1.55;color:#ffe7bf}
+    .fantasy-history-controls{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+    .fantasy-history-select-wrap{
+      display:flex;
+      align-items:center;
+      gap:10px;
+      min-width:320px;
+      flex:1 1 360px;
+      max-width:520px;
+      padding:8px 10px;
+      border-radius:999px;
+      border:1px solid rgba(124,196,255,.14);
+      background:rgba(255,255,255,.04);
+      box-shadow:inset 0 1px 0 rgba(255,255,255,.04);
+    }
+    .fantasy-history-select-label{
+      display:inline-flex;
+      align-items:center;
+      white-space:nowrap;
+      font-size:12px;
+      font-weight:800;
+      color:#d7e7ff;
+      line-height:1;
+    }
+    .fantasy-history-select{
+      width:100%;
+      min-width:0;
+      border:1px solid rgba(255,200,87,.26);
+      border-radius:999px;
+      padding:9px 40px 9px 12px;
+      background:linear-gradient(180deg, rgba(30,25,52,.96), rgba(12,12,28,.92));
+      color:#fff;
+      font:inherit;
+      font-size:13px;
+      font-weight:700;
+      box-shadow:inset 0 1px 0 rgba(255,255,255,.04);
+    }
+    .fantasy-history-select:focus{outline:none;border-color:rgba(255,200,87,.4);box-shadow:0 0 0 2px rgba(255,200,87,.12)}
+    .fantasy-history-select option{background:#171326;color:#f4f7ff}
+    @media (max-width:760px){
+      .fantasy-history-select-wrap{min-width:100%;border-radius:18px;align-items:stretch;flex-direction:column}
+      .fantasy-history-select-label{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#ffdc96}
+    }
+    .fantasy-history-meta{display:flex;gap:8px;flex-wrap:wrap}
+    .fantasy-history-meta .pill{background:rgba(255,255,255,.05);border-color:rgba(255,200,87,.18);color:#fff1d0}
     .fantasy-switcher-button{
       border:1px solid rgba(124,196,255,.16);
       border-radius:14px;
@@ -1171,7 +1227,7 @@
         </div>
         <div class="span-12 fantasy-stage fantasy-stage-wide">
           <div class="card fantasy-viewer-card">
-            <div class="section-title">Recently locked teams</div>
+            <div class="section-title">Locked teams archive</div>
             <div id="miniFantasyLockedViewer"></div>
           </div>
             <div class="card fantasy-leaderboard-card">
@@ -1388,6 +1444,7 @@
     let MINI_FANTASY_NOTICE = null;
     let MINI_FANTASY_DRAFTS = {};
     let MINI_FANTASY_ACTIVE_MATCH_NO = null;
+    let MINI_FANTASY_RECENT_MATCH_NO = null;
     let MINI_FANTASY_RECENT_OWNER_HANDLE = '';
     let MINI_FANTASY_PICKER_STATE = {
       open: false,
@@ -7807,6 +7864,34 @@ function titleBandScore(pick, live){
       return locked.length ? locked[locked.length - 1] : null;
     }
 
+    function lockedMiniFantasyFixtures(){
+      return miniFantasyAvailabilityRows()
+        .filter((fixture) => fixture.is_locked)
+        .slice()
+        .sort((a, b) => {
+          const aMs = Date.parse(a.locks_at_utc || a.datetime_utc || '');
+          const bMs = Date.parse(b.locks_at_utc || b.datetime_utc || '');
+          if (Number.isFinite(aMs) && Number.isFinite(bMs) && aMs !== bMs) return bMs - aMs;
+          return Number(b.match_no || 0) - Number(a.match_no || 0);
+        });
+    }
+
+    function selectedMiniFantasyRecentFixture(){
+      const lockedFixtures = lockedMiniFantasyFixtures();
+      if (!lockedFixtures.length) {
+        MINI_FANTASY_RECENT_MATCH_NO = null;
+        return null;
+      }
+      const targetMatchNo = Number(MINI_FANTASY_RECENT_MATCH_NO || 0) || null;
+      const selectedFixture = targetMatchNo
+        ? lockedFixtures.find((fixture) => Number(fixture.match_no || 0) === targetMatchNo) || null
+        : null;
+      if (selectedFixture) return selectedFixture;
+      const fallbackFixture = lockedFixtures[0] || mostRecentlyLockedMiniFantasyFixture();
+      MINI_FANTASY_RECENT_MATCH_NO = Number(fallbackFixture?.match_no || 0) || null;
+      return fallbackFixture;
+    }
+
     function miniFantasyRecentFixtureStage(fixture){
       if (!fixture) return 'none';
       const matchNo = Number(fixture.match_no || 0) || null;
@@ -7936,7 +8021,7 @@ function titleBandScore(pick, live){
     }
 
     function miniFantasyRecentFixtureBoardData(){
-      const fixture = mostRecentlyLockedMiniFantasyFixture();
+      const fixture = selectedMiniFantasyRecentFixture();
       const leaderboard = miniFantasyLeaderboardData();
       const leaderboardRows = Array.isArray(leaderboard.rows) ? leaderboard.rows : [];
       if (!fixture) {
@@ -8028,6 +8113,30 @@ function titleBandScore(pick, live){
       if (!cleaned.length) return '';
       if (cleaned.length <= limit) return cleaned.join(', ');
       return `${cleaned.slice(0, limit).join(', ')} +${cleaned.length - limit} more`;
+    }
+
+    function miniFantasyRecentFixtureOptions(totalUsers = 0){
+      const ownersByMatch = new Map();
+      currentMiniFantasyLeaderboardEntries().forEach((entry) => {
+        const matchNo = Number(entry?.matchNo || entry?.match_no || 0) || null;
+        const ownerHandle = normalizeOwnerId(entry?.ownerHandle || entry?.owner_handle || '');
+        if (!matchNo || !ownerHandle) return;
+        if (!ownersByMatch.has(matchNo)) ownersByMatch.set(matchNo, new Set());
+        ownersByMatch.get(matchNo).add(ownerHandle);
+      });
+      return lockedMiniFantasyFixtures().map((fixture) => {
+        const matchNo = Number(fixture?.match_no || 0) || null;
+        const lockedCount = matchNo ? (ownersByMatch.get(matchNo)?.size || 0) : 0;
+        const missingCount = Math.max(Number(totalUsers || 0) - lockedCount, 0);
+        return {
+          fixture,
+          matchNo,
+          stage: miniFantasyRecentFixtureStage(fixture),
+          lockedCount,
+          missingCount,
+          isActive: matchNo === (Number(MINI_FANTASY_RECENT_MATCH_NO || 0) || null)
+        };
+      });
     }
 
     function buildMiniFantasyStoryCards(board, selectedRow){
@@ -8600,7 +8709,7 @@ function titleBandScore(pick, live){
       }
       panel.innerHTML = `
         <div class="fantasy-leaderboard-kicker">${escapeHtml(recentBoard.fixture ? `Pick rail for Match ${recentBoard.fixture.match_no}` : 'Leaderboard rail')}</div>
-        <div class="fantasy-window-note">${recentBoard.fixture ? `Click a user and keep your eyes on the locked-team stage. The rail only changes who is in focus for Match ${escapeHtml(String(recentBoard.fixture.match_no))}.` : 'Once the first fixture locks, this rail will become the fast way to inspect each user team without opening a new screen.'}</div>
+        <div class="fantasy-window-note">${recentBoard.fixture ? `Click a user and keep your eyes on the locked-team stage. The rail always follows the fixture selected in the archive above, and right now it is showing Match ${escapeHtml(String(recentBoard.fixture.match_no))}.` : 'Once the first fixture locks, this rail will become the fast way to inspect each user team without opening a new screen.'}</div>
         <div class="fantasy-leaderboard-scroll">
           <div class="fantasy-leaderboard-list">
             ${leaderboardRows.map((row) => `
@@ -8648,12 +8757,12 @@ function titleBandScore(pick, live){
       if (!panel) return;
       const board = miniFantasyRecentFixtureBoardData();
       if (!board.fixture) {
-        panel.innerHTML = '<div class="fantasy-empty">Once the first Mini Fantasy fixture locks, this area will show the field summary and let you inspect any user team from the leaderboard.</div>';
+        panel.innerHTML = '<div class="fantasy-empty">Once the first Mini Fantasy fixture locks, this area will turn into a fixture archive so you can inspect any past locked team from the leaderboard.</div>';
         return;
       }
       const selectedRow = selectedMiniFantasyRecentRow(board);
       if (!selectedRow) {
-        panel.innerHTML = '<div class="fantasy-empty">No locked teams are available for the most recently locked fixture yet.</div>';
+        panel.innerHTML = '<div class="fantasy-empty">No locked teams are available for the selected fixture yet.</div>';
         return;
       }
       const fixtureLabel = formatFixtureLabel(board.fixture.fixture || `${board.fixture.away_team} vs ${board.fixture.home_team}`);
@@ -8663,6 +8772,8 @@ function titleBandScore(pick, live){
       const captain = selectedRow.fixtureCaptain;
       const viewedName = selectedRow.display_name || selectedRow.owner_handle;
       const storyCards = buildMiniFantasyStoryCards(board, selectedRow);
+      const fixtureOptions = miniFantasyRecentFixtureOptions(Array.isArray(board.rows) ? board.rows.length : 0);
+      const activeOption = fixtureOptions.find((option) => option.isActive) || null;
       const detailNote = selectedRow.fixtureStatus === 'did_not_lock'
         ? `${viewedName} did not save a team before this fixture locked.`
         : board.stage === 'final'
@@ -8672,11 +8783,38 @@ function titleBandScore(pick, live){
             : `${viewedName} locked this team. Points will start updating once Match ${board.fixture.match_no} begins.`;
       panel.innerHTML = `
         <div class="fantasy-entry-team">
+          <div class="fantasy-history-shell">
+            <div class="fantasy-history-head">
+              <div class="fantasy-history-copy">
+                <div class="fantasy-history-title">Most Recent Locked Fixture</div>
+                <div class="fantasy-history-sub">The viewer still defaults to the latest locked match. Use the dropdown only when you want to inspect older fixture points, then the leaderboard rail and center stage switch together.</div>
+              </div>
+              <div class="fantasy-history-controls">
+                <div class="fantasy-history-select-wrap">
+                  <label class="fantasy-history-select-label" for="miniFantasyHistorySelect">Fixture view</label>
+                  <select id="miniFantasyHistorySelect" class="fantasy-history-select">
+                    ${fixtureOptions.map((option) => {
+                      const optionFixture = option.fixture || {};
+                      const optionStatus = option.stage === 'final' ? 'Final' : option.stage === 'live' ? 'Live' : 'Locked';
+                      const optionLabel = `${option.matchNo === fixtureOptions[0]?.matchNo ? 'Latest lock - ' : ''}Match ${option.matchNo} - ${teamShort(optionFixture.home_team || optionFixture.home_team_code || '')} vs ${teamShort(optionFixture.away_team || optionFixture.away_team_code || '')} - ${optionStatus}`;
+                      return `<option value="${escapeHtml(String(option.matchNo || ''))}" ${option.isActive ? 'selected' : ''}>${escapeHtml(optionLabel)}</option>`;
+                    }).join('')}
+                  </select>
+                </div>
+                <div class="fantasy-history-meta">
+                  <span class="pill">Showing Match ${escapeHtml(String(board.fixture.match_no))}</span>
+                  <span class="pill">${escapeHtml(statusLabel)}</span>
+                  <span class="pill">${escapeHtml(String(activeOption?.lockedCount || 0))} locked team${Number(activeOption?.lockedCount || 0) === 1 ? '' : 's'}</span>
+                  ${(activeOption?.missingCount || 0) ? `<span class="pill">${escapeHtml(String(activeOption.missingCount))} missed lock</span>` : '<span class="pill">Everyone submitted</span>'}
+                </div>
+              </div>
+            </div>
+          </div>
           <div class="fantasy-picks-focus">
             <div class="fantasy-detail-header">
               <div>
                 <div class="fantasy-picks-focus-title">Now viewing ${escapeHtml(viewedName)}'s Match ${escapeHtml(String(board.fixture.match_no))} team</div>
-                <div class="fantasy-picks-focus-note">This is the center stage for the most recently locked fixture. Click another user in the leaderboard rail to swap teams without losing this view.</div>
+                <div class="fantasy-picks-focus-note">This is the center stage for the selected locked fixture. Click another user in the leaderboard rail to swap teams, or jump to a different past fixture above without losing this view.</div>
               </div>
               <div>
                 <div class="fantasy-detail-points">${escapeHtml(selectedRow.fixtureStatus === 'did_not_lock' ? '—' : formatMiniFantasyPoints(selectedRow.fixturePoints))}</div>
@@ -8722,6 +8860,16 @@ function titleBandScore(pick, live){
           <div class="fantasy-viewer-caption">${escapeHtml(detailNote)}</div>
         </div>
       `;
+      const historySelect = panel.querySelector('#miniFantasyHistorySelect');
+      if (historySelect) {
+        historySelect.onchange = () => {
+          const nextMatchNo = Number(historySelect.value || 0) || null;
+          if (!nextMatchNo || nextMatchNo === (Number(MINI_FANTASY_RECENT_MATCH_NO || 0) || null)) return;
+          MINI_FANTASY_RECENT_MATCH_NO = nextMatchNo;
+          renderMiniFantasyLeaderboard();
+          renderMiniFantasyLockedViewer();
+        };
+      }
     }
 
     async function saveMiniFantasyEntry(){

--- a/index.html
+++ b/index.html
@@ -764,14 +764,12 @@
     .fantasy-history-copy{display:grid;gap:6px;max-width:760px}
     .fantasy-history-title{font-size:13px;font-weight:900;letter-spacing:.06em;text-transform:uppercase;color:#ffd67e}
     .fantasy-history-sub{font-size:12px;line-height:1.55;color:#ffe7bf}
-    .fantasy-history-controls{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+    .fantasy-history-controls{display:grid;gap:10px;width:100%}
     .fantasy-history-select-wrap{
       display:flex;
       align-items:center;
       gap:10px;
-      min-width:320px;
-      flex:1 1 360px;
-      max-width:520px;
+      width:min(100%, 620px);
       padding:8px 10px;
       border-radius:999px;
       border:1px solid rgba(124,196,255,.14);
@@ -803,7 +801,7 @@
     .fantasy-history-select:focus{outline:none;border-color:rgba(255,200,87,.4);box-shadow:0 0 0 2px rgba(255,200,87,.12)}
     .fantasy-history-select option{background:#171326;color:#f4f7ff}
     @media (max-width:760px){
-      .fantasy-history-select-wrap{min-width:100%;border-radius:18px;align-items:stretch;flex-direction:column}
+      .fantasy-history-select-wrap{width:100%;border-radius:18px;align-items:stretch;flex-direction:column}
       .fantasy-history-select-label{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#ffdc96}
     }
     .fantasy-history-meta{display:flex;gap:8px;flex-wrap:wrap}
@@ -8795,8 +8793,7 @@ function titleBandScore(pick, live){
                   <select id="miniFantasyHistorySelect" class="fantasy-history-select">
                     ${fixtureOptions.map((option) => {
                       const optionFixture = option.fixture || {};
-                      const optionStatus = option.stage === 'final' ? 'Final' : option.stage === 'live' ? 'Live' : 'Locked';
-                      const optionLabel = `${option.matchNo === fixtureOptions[0]?.matchNo ? 'Latest lock - ' : ''}Match ${option.matchNo} - ${teamShort(optionFixture.home_team || optionFixture.home_team_code || '')} vs ${teamShort(optionFixture.away_team || optionFixture.away_team_code || '')} - ${optionStatus}`;
+                      const optionLabel = `${option.matchNo === fixtureOptions[0]?.matchNo ? 'Latest lock - ' : ''}Match ${option.matchNo} - ${teamShort(optionFixture.home_team || optionFixture.home_team_code || '')} vs ${teamShort(optionFixture.away_team || optionFixture.away_team_code || '')}`;
                       return `<option value="${escapeHtml(String(option.matchNo || ''))}" ${option.isActive ? 'selected' : ''}>${escapeHtml(optionLabel)}</option>`;
                     }).join('')}
                   </select>

--- a/tests/page.smoke.spec.mjs
+++ b/tests/page.smoke.spec.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const liveFixture = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/live_early_season.json'), 'utf8'));
+const AUTH_STORAGE_KEY = 'sp-cup-duels-auth-v1';
+const MINI_FANTASY_ENTRIES_STORAGE_KEY = 'sp-cup-mini-fantasy-entries-v1';
 
 async function setHiddenPick(page, key, value) {
   await page.locator(`#activeEntryForm input[data-pick-key="${key}"]`).evaluate((input, nextValue) => {
@@ -274,6 +276,117 @@ test('mini fantasy opens Match 14 early, shows future submit windows, and ranks 
   await expect(page.locator('#miniFantasyLeaderboard')).toContainText('Mini Bala');
   await expect(page.locator('#miniFantasyLeaderboard')).toContainText('@mini-bala');
   await expect(page.locator('#miniFantasyLeaderboard')).toContainText(/medal/i);
+
+  expect(pageErrors).toEqual([]);
+});
+
+test('mini fantasy locked fixture viewer defaults to the latest lock and can switch to older fixtures from the dropdown', async ({ page }) => {
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(String(error)));
+
+  const seededEntries = [
+    {
+      ownerHandle: 'fixture-tester',
+      displayName: 'Fixture Tester',
+      season: 'IPL 2026',
+      matchNo: 14,
+      homeTeamCode: 'DC',
+      awayTeamCode: 'GT',
+      fixtureLabel: 'Gujarat Titans vs Delhi Capitals',
+      fixtureDatetimeUtc: '2026-04-08T14:00:00Z',
+      selectedPlayerIds: ['dc_kl-rahul', 'dc_kuldeep-yadav', 'gt_shubman-gill', 'gt_sai-kishore'],
+      captainPlayerId: 'gt_shubman-gill',
+      priceSnapshot: {},
+      spentCredits: 31,
+      savedAt: '2026-04-08T13:20:00Z'
+    },
+    {
+      ownerHandle: 'fixture-tester',
+      displayName: 'Fixture Tester',
+      season: 'IPL 2026',
+      matchNo: 15,
+      homeTeamCode: 'KKR',
+      awayTeamCode: 'LSG',
+      fixtureLabel: 'Lucknow Super Giants vs Kolkata Knight Riders',
+      fixtureDatetimeUtc: '2026-04-09T14:00:00Z',
+      selectedPlayerIds: ['kkr_ajinkya-rahane', 'kkr_sunil-narine', 'lsg_rishabh-pant', 'lsg_nicholas-pooran'],
+      captainPlayerId: 'kkr_sunil-narine',
+      priceSnapshot: {},
+      spentCredits: 31,
+      savedAt: '2026-04-09T13:25:00Z'
+    },
+    {
+      ownerHandle: 'other-user',
+      displayName: 'Other User',
+      season: 'IPL 2026',
+      matchNo: 14,
+      homeTeamCode: 'DC',
+      awayTeamCode: 'GT',
+      fixtureLabel: 'Gujarat Titans vs Delhi Capitals',
+      fixtureDatetimeUtc: '2026-04-08T14:00:00Z',
+      selectedPlayerIds: ['dc_abishek-porel', 'dc_axar-patel', 'gt_shubman-gill', 'gt_mohammed-siraj'],
+      captainPlayerId: 'dc_axar-patel',
+      priceSnapshot: {},
+      spentCredits: 30,
+      savedAt: '2026-04-08T13:18:00Z'
+    },
+    {
+      ownerHandle: 'other-user',
+      displayName: 'Other User',
+      season: 'IPL 2026',
+      matchNo: 15,
+      homeTeamCode: 'KKR',
+      awayTeamCode: 'LSG',
+      fixtureLabel: 'Lucknow Super Giants vs Kolkata Knight Riders',
+      fixtureDatetimeUtc: '2026-04-09T14:00:00Z',
+      selectedPlayerIds: ['kkr_quinton-de-kock', 'kkr_varun-chakaravarthy', 'lsg_aiden-markram', 'lsg_nicholas-pooran'],
+      captainPlayerId: 'lsg_nicholas-pooran',
+      priceSnapshot: {},
+      spentCredits: 29,
+      savedAt: '2026-04-09T13:16:00Z'
+    }
+  ];
+
+  await page.addInitScript(({ authKey, entriesKey, entries }) => {
+    window.__DUELS_TEST_NOW__ = '2026-04-09T15:00:00Z';
+    window.DUELS_BACKEND_CONFIG = { enabled: false };
+    window.localStorage.setItem(authKey, JSON.stringify({
+      displayName: 'Fixture Tester',
+      ownerId: 'fixture-tester',
+      authSource: 'local'
+    }));
+    window.localStorage.setItem(entriesKey, JSON.stringify({ version: 1, entries }));
+  }, {
+    authKey: AUTH_STORAGE_KEY,
+    entriesKey: MINI_FANTASY_ENTRIES_STORAGE_KEY,
+    entries: seededEntries
+  });
+
+  await page.route(/data\/live\.json(\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(liveFixture)
+    });
+  });
+
+  await page.goto('http://127.0.0.1:4173/index.html?room=sp-cup-2026');
+
+  await expect(page.locator('#profileChipButton')).toContainText('Fixture Tester');
+  await expect(page.locator('#miniFantasyLockedViewer')).toContainText('Most Recent Locked Fixture');
+  await expect(page.locator('#miniFantasyHistorySelect')).toHaveValue('15');
+  await expect(page.locator('#miniFantasyHistorySelect')).toContainText('Latest lock - Match 15');
+  await expect(page.locator('#miniFantasyLockedViewer')).toContainText("Now viewing Fixture Tester's Match 15 team");
+  await expect(page.locator('#miniFantasyLeaderboard')).toContainText('Pick rail for Match 15');
+
+  await page.locator('#miniFantasyHistorySelect').selectOption('14');
+
+  await expect(page.locator('#miniFantasyHistorySelect')).toHaveValue('14');
+  await expect(page.locator('#miniFantasyLockedViewer')).toContainText("Now viewing Fixture Tester's Match 14 team");
+  await expect(page.locator('#miniFantasyLockedViewer')).toContainText('Fixture: Match 14');
+  await expect(page.locator('#miniFantasyLeaderboard')).toContainText('Pick rail for Match 14');
+  await expect(page.locator('#miniFantasyLeaderboard')).toContainText('Fixture Tester');
+  await expect(page.locator('#miniFantasyLeaderboard')).toContainText('Other User');
 
   expect(pageErrors).toEqual([]);
 });


### PR DESCRIPTION
### Summary

- Keep the locked teams viewer anchored to the most recently locked fixture by default instead of changing the primary behavior
- Add a compact dropdown to inspect older locked fixtures without overcrowding the page as more matches finish
- Sync the locked team stage and leaderboard rail so both update together when a past fixture is selected
- Refine the fixture selector styling so it matches the existing badge language and renders readable dropdown options on Windows
- Add browser coverage for the locked fixture selector flow, including defaulting to the latest lock and switching to an older fixture

### Testing

- tests/page.smoke.spec.mjs