### PR TITLE
fix: hide unlocked mini fantasy teams from public reads

### DIFF
--- a/docs/duels_backend_supabase.sql
+++ b/docs/duels_backend_supabase.sql
@@ -205,10 +205,19 @@ with check (
 
 drop policy if exists "users read their own mini fantasy entries" on public.mini_fantasy_entries;
 drop policy if exists "mini fantasy entries are public readable" on public.mini_fantasy_entries;
-create policy "mini fantasy entries are public readable"
+drop policy if exists "locked mini fantasy entries are public readable" on public.mini_fantasy_entries;
+
+create policy "users read their own mini fantasy entries"
 on public.mini_fantasy_entries
 for select
-using (true);
+using (auth.uid() = user_id);
+
+create policy "locked mini fantasy entries are public readable"
+on public.mini_fantasy_entries
+for select
+using (
+  timezone('utc', now()) >= fixture_datetime_utc - interval '1 minute'
+);
 
 drop policy if exists "users insert their own mini fantasy entries before lock" on public.mini_fantasy_entries;
 create policy "users insert their own mini fantasy entries before lock"

--- a/duels-backend.js
+++ b/duels-backend.js
@@ -790,11 +790,13 @@ function normalizeMiniFantasyEntryRow(row) {
       async listPublicMiniFantasyEntries({ season, currentUser } = {}) {
         const activeSession = await ensureFreshSession();
         const safeSeason = normalizeWhitespace(season || '');
+        const publicVisibleAtUtc = new Date(Date.now() + 60 * 1000).toISOString();
         const rows = await restRequest(config.tables.miniFantasyEntries, {
           method: 'GET',
           query: {
             select: 'id,user_id,owner_handle,display_name,season,match_no,home_team_code,away_team_code,fixture_label,fixture_datetime_utc,selected_player_ids,captain_player_id,price_snapshot,spent_credits,saved_at,created_at,updated_at',
             ...(safeSeason ? { season: `eq.${safeSeason}` } : {}),
+            fixture_datetime_utc: `lte.${publicVisibleAtUtc}`,
             order: 'saved_at.desc.nullslast,fixture_datetime_utc.asc.nullslast,match_no.asc'
           },
           accessToken: activeSession?.access_token || currentUser?.accessToken || null

--- a/tests/duels-backend.wiring.test.mjs
+++ b/tests/duels-backend.wiring.test.mjs
@@ -28,6 +28,7 @@ test('backend config, adapter, and setup docs are present for real auth + duel a
   assert.match(backendJs, /saveOwnedEntry/);
   assert.match(backendJs, /listMiniFantasyEntries/);
   assert.match(backendJs, /listPublicMiniFantasyEntries/);
+  assert.match(backendJs, /fixture_datetime_utc:\s*`lte\.\$\{publicVisibleAtUtc\}`/);
   assert.match(backendJs, /upsertMiniFantasyEntry/);
 
   assert.match(setupDoc, /Supabase/i);
@@ -38,5 +39,7 @@ test('backend config, adapter, and setup docs are present for real auth + duel a
   assert.match(schemaSql, /create table if not exists public\.duels/i);
   assert.match(schemaSql, /create table if not exists public\.duel_entries/i);
   assert.match(schemaSql, /create table if not exists public\.mini_fantasy_entries/i);
+  assert.match(schemaSql, /create policy "users read their own mini fantasy entries"/i);
+  assert.match(schemaSql, /create policy "locked mini fantasy entries are public readable"/i);
   assert.match(schemaSql, /enable row level security/i);
 });


### PR DESCRIPTION
## Summary
- stop public reads of Mini Fantasy entries before fixture lock
- allow users to read only their own entries before lock
- keep locked entries publicly readable after lock
- add a defense-in-depth backend query filter so the normal public read path only asks for already-locked fixtures
- update backend wiring coverage for the new locked-only policy and query filter

## Why
Users could inspect network calls / DevTools and see submitted Mini Fantasy teams before lock because the existing Supabase policy allowed public `select` on `mini_fantasy_entries` with `using (true)`.

## Required follow-up
Run the updated SQL policy in Supabase before/alongside merge so the RLS change takes effect.

## Validation
- node test suite passed (`88/88`)
