### PR TITLE
feat: show fantasy points in player picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -9443,7 +9443,7 @@ function titleBandScore(pick, live){
                 <div class="fantasy-picker-row">
                   <div>
                     <div class="fantasy-slot-name">${escapeHtml(player.name)}</div>
-                    <div class="fantasy-picker-role">${escapeHtml(player.team)} - ${escapeHtml(player.role.replace('_', ' '))}${player.matches_played ? ` - ${escapeHtml(String(player.matches_played))} matches` : ''}${draft.captainPlayerId === player.player_id ? ' - captain' : ''}</div>
+                    <div class="fantasy-picker-role">${escapeHtml(player.team)} - ${escapeHtml(player.role.replace('_', ' '))} - ${escapeHtml(formatMiniFantasyPoints(player.season_total_points || 0))} pts total${player.matches_played ? ` - ${escapeHtml(formatMiniFantasyPoints(player.last_match_points || 0))} last match - ${escapeHtml(String(player.matches_played))} matches` : ''}${draft.captainPlayerId === player.player_id ? ' - captain' : ''}</div>
                     ${(player.pickedInOtherSlot || player.selectedInCurrentSlot || player.selectedSlotIndex !== -1) ? `
                       <div class="fantasy-picker-meta-row">
                         <div class="fantasy-picker-meta-badges">

--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -797,6 +797,8 @@ export function buildFixturePlayerPool({
         final_price: Number.isFinite(price?.final_price) ? price.final_price : DEFAULT_PRICE_JOB_META.default_initial_price,
         old_price: price?.old_price ?? null,
         matches_played: Number(price?.matches_played || 0),
+        season_total_points: Number(price?.season_total_points || 0),
+        last_match_points: Number(price?.last_match_points || 0),
         adjusted_score: Number(price?.adjusted_score || 0),
         last_match_played_at_utc: price?.last_match_played_at_utc || null
       };

--- a/mini-fantasy/pricing-engine.js
+++ b/mini-fantasy/pricing-engine.js
@@ -80,6 +80,14 @@ export function computeSeasonAveragePoints(matchPoints) {
   return roundTo(average(matchPoints), 2);
 }
 
+export function computeSeasonTotalPoints(matchPoints) {
+  if (!Array.isArray(matchPoints) || matchPoints.length === 0) {
+    return 0;
+  }
+
+  return roundTo(matchPoints.reduce((sum, points) => sum + Number(points || 0), 0), 2);
+}
+
 export function computeRecentAveragePoints(matchPoints, windowSize) {
   return roundTo(average(getRecentMatchPoints(matchPoints, windowSize)), 2);
 }
@@ -286,6 +294,7 @@ function derivePlayerInputs(player, jobMeta) {
     basePrice,
     maxDailyPriceStep: jobMeta.max_daily_price_step,
     recoveredHistory: Boolean(player.recovered_history) && effectiveMatchesPlayed > 0,
+    matchPoints,
     seasonAveragePoints,
     recentAveragePoints,
     lastMatchPoints,
@@ -362,6 +371,7 @@ export function generatePrices(input) {
         final_price: finalPrice,
         price_change: priceChange,
         matches_played: entry.effectiveMatchesPlayed,
+        season_total_points: computeSeasonTotalPoints(entry.matchPoints),
         season_avg_points: entry.seasonAveragePoints,
         recent_avg_points: entry.recentAveragePoints,
         last_match_points: entry.lastMatchPoints,

--- a/mini-fantasy/pricing-engine.ts
+++ b/mini-fantasy/pricing-engine.ts
@@ -72,6 +72,7 @@ export interface PricingPlayerOutput {
   final_price: number;
   price_change: number;
   matches_played: number;
+  season_total_points: number;
   season_avg_points: number;
   recent_avg_points: number;
   last_match_points: number;
@@ -220,6 +221,14 @@ export function getRecentMatchPoints(matchPoints: number[], windowSize: number):
 
 export function computeSeasonAveragePoints(matchPoints: number[]): number {
   return roundTo(average(matchPoints), 2);
+}
+
+export function computeSeasonTotalPoints(matchPoints: number[]): number {
+  if (!Array.isArray(matchPoints) || matchPoints.length === 0) {
+    return 0;
+  }
+
+  return roundTo(matchPoints.reduce((sum, points) => sum + Number(points || 0), 0), 2);
 }
 
 export function computeRecentAveragePoints(matchPoints: number[], windowSize: number): number {
@@ -457,6 +466,7 @@ function derivePlayerInputs(player: PricingPlayerInput, jobMeta: PricingJobMetaI
     basePrice,
     maxDailyPriceStep: jobMeta.max_daily_price_step,
     recoveredHistory: Boolean(player.recovered_history) && effectiveMatchesPlayed > 0,
+    matchPoints,
     seasonAveragePoints,
     recentAveragePoints,
     lastMatchPoints,
@@ -540,6 +550,7 @@ export function generatePrices(input: PricingJobInput): PricingJobOutput {
         final_price: finalPrice,
         price_change: priceChange,
         matches_played: entry.effectiveMatchesPlayed,
+        season_total_points: computeSeasonTotalPoints(entry.matchPoints),
         season_avg_points: entry.seasonAveragePoints,
         recent_avg_points: entry.recentAveragePoints,
         last_match_points: entry.lastMatchPoints,

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -457,6 +457,10 @@ test('generateMiniFantasyPriceBook and buildFixturePlayerPool work from live his
 
   assert.equal(priceBook.players.length, 4);
   assert.equal(priceBook.summary.total_players_received, 4);
+  assert.equal(priceBook.players.find((player) => player.name === 'DC Batter')?.season_total_points, 62);
+  assert.equal(priceBook.players.find((player) => player.name === 'GT Bowler')?.season_total_points, 18);
+  assert.equal(priceBook.players.find((player) => player.name === 'DC Batter')?.last_match_points, 62);
+  assert.equal(priceBook.players.find((player) => player.name === 'GT Bowler')?.last_match_points, 18);
 
   const pool = buildFixturePlayerPool({
     fixture: {
@@ -473,6 +477,10 @@ test('generateMiniFantasyPriceBook and buildFixturePlayerPool work from live his
 
   assert.equal(pool.length, 4);
   assert.equal(pool[0].team <= pool[pool.length - 1].team, true);
+  assert.equal(pool.find((player) => player.name === 'DC Batter')?.season_total_points, 62);
+  assert.equal(pool.find((player) => player.name === 'GT Bowler')?.season_total_points, 18);
+  assert.equal(pool.find((player) => player.name === 'DC Batter')?.last_match_points, 62);
+  assert.equal(pool.find((player) => player.name === 'GT Bowler')?.last_match_points, 18);
 });
 
 test('generateMiniFantasyPriceBook marks uncapped players and caps them at 9 credits', () => {


### PR DESCRIPTION
## Summary
- show each player's total Mini Fantasy points in the player picker
- show each player's last-match points in the same compact picker stat line
- thread the new point fields through the Mini Fantasy price book and fixture player pool
- extend Mini Fantasy engine coverage for the new picker data

## Why
When choosing a player, the picker currently shows only matches played. Adding total points plus last-match points gives users, especially newer players, a much better feel for both season value and recent form without cluttering the picker.

## Validation
- node test suite passed (`88/88`)
