### PR TITLE
fix: repair fantasy alias history matching

### DIFF
--- a/data/mini_fantasy_prices.json
+++ b/data/mini_fantasy_prices.json
@@ -17,9 +17,9 @@
   "summary": {
     "total_players_received": 254,
     "eligible_players_ranked": 254,
-    "price_rises": 0,
+    "price_rises": 1,
     "price_drops": 1,
-    "price_unchanged": 253
+    "price_unchanged": 252
   },
   "players": [
     {
@@ -156,7 +156,7 @@
       "score_basis": 36.12,
       "reliability_factor": 1,
       "adjusted_score": 36.12,
-      "percentile": 86.56,
+      "percentile": 86.17,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -183,10 +183,10 @@
       "score_basis": 31.12,
       "reliability_factor": 1,
       "adjusted_score": 31.12,
-      "percentile": 79.84,
+      "percentile": 79.45,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 79.84",
+        "Target price mapped from percentile 79.45",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -212,10 +212,10 @@
       "score_basis": 15,
       "reliability_factor": 0.75,
       "adjusted_score": 11.25,
-      "percentile": 55.34,
+      "percentile": 54.55,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 55.34",
+        "Target price mapped from percentile 54.55",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -241,10 +241,10 @@
       "score_basis": 33.36,
       "reliability_factor": 1,
       "adjusted_score": 33.36,
-      "percentile": 83.4,
+      "percentile": 83,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 83.4",
+        "Target price mapped from percentile 83",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -270,7 +270,7 @@
       "score_basis": 15,
       "reliability_factor": 0.5,
       "adjusted_score": 7.5,
-      "percentile": 51.38,
+      "percentile": 50.59,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -297,7 +297,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -325,10 +325,10 @@
       "score_basis": 39.5,
       "reliability_factor": 0.5,
       "adjusted_score": 19.75,
-      "percentile": 65.61,
+      "percentile": 65.22,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 65.61",
+        "Target price mapped from percentile 65.22",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -354,7 +354,7 @@
       "score_basis": 15.5,
       "reliability_factor": 0.5,
       "adjusted_score": 7.75,
-      "percentile": 52.17,
+      "percentile": 51.38,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -381,7 +381,7 @@
       "score_basis": 9.67,
       "reliability_factor": 0.75,
       "adjusted_score": 7.25,
-      "percentile": 50.99,
+      "percentile": 50.2,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -408,7 +408,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -436,7 +436,7 @@
       "score_basis": 26.5,
       "reliability_factor": 0.5,
       "adjusted_score": 13.25,
-      "percentile": 57.31,
+      "percentile": 56.52,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -463,10 +463,10 @@
       "score_basis": 3,
       "reliability_factor": 0.25,
       "adjusted_score": 0.75,
-      "percentile": 44.47,
+      "percentile": 43.68,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 44.47",
+        "Target price mapped from percentile 43.68",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T14:00:00Z"
@@ -492,7 +492,7 @@
       "score_basis": 13.64,
       "reliability_factor": 1,
       "adjusted_score": 13.64,
-      "percentile": 58.1,
+      "percentile": 57.31,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -519,10 +519,10 @@
       "score_basis": 10.8,
       "reliability_factor": 1,
       "adjusted_score": 10.8,
-      "percentile": 54.55,
+      "percentile": 53.75,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.55",
+        "Target price mapped from percentile 53.75",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -548,7 +548,7 @@
       "score_basis": 2,
       "reliability_factor": 0.25,
       "adjusted_score": 0.5,
-      "percentile": 43.87,
+      "percentile": 43.08,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -575,7 +575,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -603,7 +603,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -631,7 +631,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -659,7 +659,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -687,7 +687,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -715,7 +715,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -743,10 +743,10 @@
       "score_basis": 25.6,
       "reliability_factor": 1,
       "adjusted_score": 25.6,
-      "percentile": 73.12,
+      "percentile": 72.73,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 73.12",
+        "Target price mapped from percentile 72.73",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-11T14:00:00Z"
@@ -827,7 +827,7 @@
       "score_basis": 34.5,
       "reliability_factor": 1,
       "adjusted_score": 34.5,
-      "percentile": 84.98,
+      "percentile": 84.58,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -854,10 +854,10 @@
       "score_basis": 15.8,
       "reliability_factor": 1,
       "adjusted_score": 15.8,
-      "percentile": 60.08,
+      "percentile": 59.29,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 60.08",
+        "Target price mapped from percentile 59.29",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-11T14:00:00Z"
@@ -883,7 +883,7 @@
       "score_basis": 28.4,
       "reliability_factor": 1,
       "adjusted_score": 28.4,
-      "percentile": 76.28,
+      "percentile": 75.89,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -939,41 +939,13 @@
       "score_basis": 11.9,
       "reliability_factor": 1,
       "adjusted_score": 11.9,
-      "percentile": 55.73,
+      "percentile": 54.94,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 55.73",
+        "Target price mapped from percentile 54.94",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-11T14:00:00Z"
-    },
-    {
-      "player_id": "dc_lungisani-ngidi",
-      "name": "Lungisani Ngidi",
-      "team": "DC",
-      "role": "bowler",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 8,
-      "initial_price": 8,
-      "target_price": 5,
-      "smoothed_price": 8,
-      "final_price": 8,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_total_points": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 22.33,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
     },
     {
       "player_id": "dc_t-natarajan",
@@ -996,10 +968,10 @@
       "score_basis": 13.1,
       "reliability_factor": 1,
       "adjusted_score": 13.1,
-      "percentile": 56.92,
+      "percentile": 56.13,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.92",
+        "Target price mapped from percentile 56.13",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-11T14:00:00Z"
@@ -1025,7 +997,7 @@
       "score_basis": 31,
       "reliability_factor": 0.25,
       "adjusted_score": 7.75,
-      "percentile": 52.17,
+      "percentile": 51.38,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1040,7 +1012,7 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
@@ -1052,9 +1024,40 @@
       "score_basis": 4,
       "reliability_factor": 0.25,
       "adjusted_score": 1,
-      "percentile": 45.06,
+      "percentile": 44.27,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 44.27",
+        "Applied smoothing against the target price"
+      ],
+      "last_match_played_at_utc": "2026-04-11T14:00:00Z"
+    },
+    {
+      "player_id": "dc_lungisani-ngidi",
+      "name": "Lungisani Ngidi",
+      "team": "DC",
+      "role": "bowler",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 8,
+      "initial_price": 8,
+      "target_price": 7,
+      "smoothed_price": 7,
+      "final_price": 7,
+      "price_change": -1,
+      "matches_played": 4,
+      "season_total_points": 115,
+      "season_avg_points": 28.75,
+      "recent_avg_points": 13.67,
+      "last_match_points": 1,
+      "score_basis": 19.7,
+      "reliability_factor": 1,
+      "adjusted_score": 19.7,
+      "percentile": 64.82,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Recovered real match history from a previously blank price; used the corrected target price immediately",
+        "Target price mapped from percentile 64.82"
       ],
       "last_match_played_at_utc": "2026-04-11T14:00:00Z"
     },
@@ -1079,7 +1082,7 @@
       "score_basis": 12,
       "reliability_factor": 0.75,
       "adjusted_score": 9,
-      "percentile": 52.96,
+      "percentile": 52.17,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1106,7 +1109,7 @@
       "score_basis": 9,
       "reliability_factor": 0.75,
       "adjusted_score": 6.75,
-      "percentile": 50.2,
+      "percentile": 49.41,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1133,7 +1136,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1161,7 +1164,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1189,7 +1192,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1217,7 +1220,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1245,7 +1248,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1273,7 +1276,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1301,7 +1304,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1329,7 +1332,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1357,7 +1360,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1385,7 +1388,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1413,7 +1416,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1441,10 +1444,10 @@
       "score_basis": 39.1,
       "reliability_factor": 1,
       "adjusted_score": 39.1,
-      "percentile": 89.72,
+      "percentile": 89.33,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 89.72",
+        "Target price mapped from percentile 89.33",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T10:00:00Z"
@@ -1499,10 +1502,10 @@
       "score_basis": 28.2,
       "reliability_factor": 1,
       "adjusted_score": 28.2,
-      "percentile": 75.89,
+      "percentile": 75.49,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 75.89",
+        "Target price mapped from percentile 75.49",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T10:00:00Z"
@@ -1557,7 +1560,7 @@
       "score_basis": 39.3,
       "reliability_factor": 1,
       "adjusted_score": 39.3,
-      "percentile": 90.12,
+      "percentile": 89.72,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1613,7 +1616,7 @@
       "score_basis": 20.3,
       "reliability_factor": 1,
       "adjusted_score": 20.3,
-      "percentile": 67.59,
+      "percentile": 67.19,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1640,7 +1643,7 @@
       "score_basis": 20.6,
       "reliability_factor": 1,
       "adjusted_score": 20.6,
-      "percentile": 68.58,
+      "percentile": 68.18,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1667,10 +1670,10 @@
       "score_basis": 26,
       "reliability_factor": 0.25,
       "adjusted_score": 6.5,
-      "percentile": 49.21,
+      "percentile": 48.42,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 49.21",
+        "Target price mapped from percentile 48.42",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T14:00:00Z"
@@ -1696,7 +1699,7 @@
       "score_basis": 20,
       "reliability_factor": 1,
       "adjusted_score": 20,
-      "percentile": 66.8,
+      "percentile": 66.4,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1723,10 +1726,10 @@
       "score_basis": 9,
       "reliability_factor": 0.75,
       "adjusted_score": 6.75,
-      "percentile": 50.2,
+      "percentile": 49.41,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 50.2",
+        "Target price mapped from percentile 49.41",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T10:00:00Z"
@@ -1752,10 +1755,10 @@
       "score_basis": 37.3,
       "reliability_factor": 1,
       "adjusted_score": 37.3,
-      "percentile": 88.14,
+      "percentile": 87.75,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 88.14",
+        "Target price mapped from percentile 87.75",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T10:00:00Z"
@@ -1781,7 +1784,7 @@
       "score_basis": 14,
       "reliability_factor": 1,
       "adjusted_score": 14,
-      "percentile": 58.5,
+      "percentile": 57.71,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1808,7 +1811,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1836,7 +1839,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1864,7 +1867,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1892,7 +1895,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1920,7 +1923,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1948,7 +1951,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1976,7 +1979,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2004,7 +2007,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2032,7 +2035,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2060,7 +2063,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2088,7 +2091,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2116,7 +2119,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2144,7 +2147,7 @@
       "score_basis": 32.2,
       "reliability_factor": 1,
       "adjusted_score": 32.2,
-      "percentile": 81.03,
+      "percentile": 80.63,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2171,7 +2174,7 @@
       "score_basis": 36.32,
       "reliability_factor": 1,
       "adjusted_score": 36.32,
-      "percentile": 87.35,
+      "percentile": 86.96,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2198,10 +2201,10 @@
       "score_basis": 53.5,
       "reliability_factor": 0.5,
       "adjusted_score": 26.75,
-      "percentile": 75.49,
+      "percentile": 75.1,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 75.49",
+        "Target price mapped from percentile 75.1",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T14:00:00Z"
@@ -2227,10 +2230,10 @@
       "score_basis": 24.4,
       "reliability_factor": 1,
       "adjusted_score": 24.4,
-      "percentile": 71.34,
+      "percentile": 70.95,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 71.34",
+        "Target price mapped from percentile 70.95",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -2256,7 +2259,7 @@
       "score_basis": 26,
       "reliability_factor": 1,
       "adjusted_score": 26,
-      "percentile": 74.31,
+      "percentile": 73.91,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2283,10 +2286,10 @@
       "score_basis": 15.4,
       "reliability_factor": 1,
       "adjusted_score": 15.4,
-      "percentile": 59.29,
+      "percentile": 58.5,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 59.29",
+        "Target price mapped from percentile 58.5",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -2312,10 +2315,10 @@
       "score_basis": 10.96,
       "reliability_factor": 1,
       "adjusted_score": 10.96,
-      "percentile": 54.94,
+      "percentile": 54.15,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.94",
+        "Target price mapped from percentile 54.15",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -2341,7 +2344,7 @@
       "score_basis": 29.4,
       "reliability_factor": 1,
       "adjusted_score": 29.4,
-      "percentile": 77.87,
+      "percentile": 77.47,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2368,7 +2371,7 @@
       "score_basis": 22.3,
       "reliability_factor": 1,
       "adjusted_score": 22.3,
-      "percentile": 69.17,
+      "percentile": 68.77,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2395,7 +2398,7 @@
       "score_basis": 31.1,
       "reliability_factor": 1,
       "adjusted_score": 31.1,
-      "percentile": 79.45,
+      "percentile": 79.05,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2422,10 +2425,10 @@
       "score_basis": 34.2,
       "reliability_factor": 1,
       "adjusted_score": 34.2,
-      "percentile": 84.39,
+      "percentile": 83.99,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 84.39",
+        "Target price mapped from percentile 83.99",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -2451,7 +2454,7 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 46.25,
+      "percentile": 45.45,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2478,10 +2481,10 @@
       "score_basis": 49.5,
       "reliability_factor": 0.5,
       "adjusted_score": 24.75,
-      "percentile": 71.94,
+      "percentile": 71.54,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 71.94",
+        "Target price mapped from percentile 71.54",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
@@ -2495,7 +2498,7 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
@@ -2507,9 +2510,11 @@
       "score_basis": 2,
       "reliability_factor": 0.75,
       "adjusted_score": 1.5,
-      "percentile": 45.45,
+      "percentile": 44.66,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 44.66",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00Z"
     },
@@ -2534,7 +2539,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2562,7 +2567,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2590,7 +2595,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2618,7 +2623,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2646,7 +2651,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2674,7 +2679,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2702,7 +2707,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2730,7 +2735,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2758,7 +2763,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2786,7 +2791,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2843,10 +2848,10 @@
       "score_basis": 28.68,
       "reliability_factor": 1,
       "adjusted_score": 28.68,
-      "percentile": 76.68,
+      "percentile": 76.28,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 76.68",
+        "Target price mapped from percentile 76.28",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -2872,7 +2877,7 @@
       "score_basis": 38,
       "reliability_factor": 1,
       "adjusted_score": 38,
-      "percentile": 88.93,
+      "percentile": 88.54,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2899,10 +2904,10 @@
       "score_basis": 10.16,
       "reliability_factor": 1,
       "adjusted_score": 10.16,
-      "percentile": 53.36,
+      "percentile": 52.57,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 53.36",
+        "Target price mapped from percentile 52.57",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -2928,7 +2933,7 @@
       "score_basis": 26.2,
       "reliability_factor": 1,
       "adjusted_score": 26.2,
-      "percentile": 75.1,
+      "percentile": 74.7,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2955,10 +2960,10 @@
       "score_basis": 35.28,
       "reliability_factor": 1,
       "adjusted_score": 35.28,
-      "percentile": 85.77,
+      "percentile": 85.38,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 85.77",
+        "Target price mapped from percentile 85.38",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -2984,7 +2989,7 @@
       "score_basis": 25.68,
       "reliability_factor": 1,
       "adjusted_score": 25.68,
-      "percentile": 73.52,
+      "percentile": 73.12,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3011,10 +3016,10 @@
       "score_basis": 31,
       "reliability_factor": 0.25,
       "adjusted_score": 7.75,
-      "percentile": 52.17,
+      "percentile": 51.38,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 52.17",
+        "Target price mapped from percentile 51.38",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-01T14:00:00Z"
@@ -3057,7 +3062,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -3069,9 +3074,11 @@
       "score_basis": 19.64,
       "reliability_factor": 1,
       "adjusted_score": 19.64,
-      "percentile": 65.22,
+      "percentile": 64.43,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 64.43",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
     },
@@ -3096,7 +3103,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3124,10 +3131,10 @@
       "score_basis": 19.8,
       "reliability_factor": 1,
       "adjusted_score": 19.8,
-      "percentile": 66.01,
+      "percentile": 65.61,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 66.01",
+        "Target price mapped from percentile 65.61",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -3153,7 +3160,7 @@
       "score_basis": 12.5,
       "reliability_factor": 0.5,
       "adjusted_score": 6.25,
-      "percentile": 48.62,
+      "percentile": 47.83,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3180,7 +3187,7 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 46.25,
+      "percentile": 45.45,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3207,7 +3214,7 @@
       "score_basis": 25,
       "reliability_factor": 0.5,
       "adjusted_score": 12.5,
-      "percentile": 56.52,
+      "percentile": 55.73,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3234,7 +3241,7 @@
       "score_basis": 16.72,
       "reliability_factor": 1,
       "adjusted_score": 16.72,
-      "percentile": 62.06,
+      "percentile": 61.26,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3261,7 +3268,7 @@
       "score_basis": 13.48,
       "reliability_factor": 1,
       "adjusted_score": 13.48,
-      "percentile": 57.71,
+      "percentile": 56.92,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3288,7 +3295,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3316,7 +3323,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3344,7 +3351,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3372,7 +3379,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3400,7 +3407,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3428,7 +3435,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3456,7 +3463,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3484,7 +3491,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3512,7 +3519,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3598,10 +3605,10 @@
       "score_basis": 28.8,
       "reliability_factor": 1,
       "adjusted_score": 28.8,
-      "percentile": 77.08,
+      "percentile": 76.68,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 77.08",
+        "Target price mapped from percentile 76.68",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T14:00:00Z"
@@ -3627,10 +3634,10 @@
       "score_basis": 25.72,
       "reliability_factor": 1,
       "adjusted_score": 25.72,
-      "percentile": 73.91,
+      "percentile": 73.52,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 73.91",
+        "Target price mapped from percentile 73.52",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -3656,10 +3663,10 @@
       "score_basis": 24.4,
       "reliability_factor": 1,
       "adjusted_score": 24.4,
-      "percentile": 71.34,
+      "percentile": 70.95,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 71.34",
+        "Target price mapped from percentile 70.95",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -3685,10 +3692,10 @@
       "score_basis": 20.6,
       "reliability_factor": 1,
       "adjusted_score": 20.6,
-      "percentile": 68.58,
+      "percentile": 68.18,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 68.58",
+        "Target price mapped from percentile 68.18",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -3714,10 +3721,10 @@
       "score_basis": 25,
       "reliability_factor": 0.75,
       "adjusted_score": 18.75,
-      "percentile": 64.82,
+      "percentile": 64.03,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.82",
+        "Target price mapped from percentile 64.03",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -3743,10 +3750,10 @@
       "score_basis": 26,
       "reliability_factor": 0.25,
       "adjusted_score": 6.5,
-      "percentile": 49.21,
+      "percentile": 48.42,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 49.21",
+        "Target price mapped from percentile 48.42",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T10:00:00Z"
@@ -3772,10 +3779,10 @@
       "score_basis": 33.1,
       "reliability_factor": 1,
       "adjusted_score": 33.1,
-      "percentile": 82.61,
+      "percentile": 82.21,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 82.61",
+        "Target price mapped from percentile 82.21",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -3801,10 +3808,10 @@
       "score_basis": 34,
       "reliability_factor": 0.5,
       "adjusted_score": 17,
-      "percentile": 63.04,
+      "percentile": 62.25,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 63.04",
+        "Target price mapped from percentile 62.25",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T14:00:00Z"
@@ -3830,10 +3837,10 @@
       "score_basis": 32.36,
       "reliability_factor": 1,
       "adjusted_score": 32.36,
-      "percentile": 81.42,
+      "percentile": 81.03,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 81.42",
+        "Target price mapped from percentile 81.03",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -3859,7 +3866,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3887,10 +3894,10 @@
       "score_basis": 32.68,
       "reliability_factor": 1,
       "adjusted_score": 32.68,
-      "percentile": 82.21,
+      "percentile": 81.82,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 82.21",
+        "Target price mapped from percentile 81.82",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -3916,7 +3923,7 @@
       "score_basis": 7.67,
       "reliability_factor": 0.75,
       "adjusted_score": 5.75,
-      "percentile": 48.22,
+      "percentile": 47.43,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3943,10 +3950,10 @@
       "score_basis": 1,
       "reliability_factor": 0.75,
       "adjusted_score": 0.75,
-      "percentile": 44.47,
+      "percentile": 43.68,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 44.47",
+        "Target price mapped from percentile 43.68",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T14:00:00Z"
@@ -3972,7 +3979,7 @@
       "score_basis": 16.84,
       "reliability_factor": 1,
       "adjusted_score": 16.84,
-      "percentile": 62.45,
+      "percentile": 61.66,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3999,7 +4006,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4027,7 +4034,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4055,7 +4062,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4083,7 +4090,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4111,7 +4118,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4139,7 +4146,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4167,7 +4174,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4195,10 +4202,10 @@
       "score_basis": 5,
       "reliability_factor": 0.75,
       "adjusted_score": 3.75,
-      "percentile": 47.43,
+      "percentile": 46.64,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 47.43",
+        "Target price mapped from percentile 46.64",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T14:00:00Z"
@@ -4224,7 +4231,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4238,12 +4245,12 @@
       "role": "bowler",
       "is_uncapped": false,
       "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
+      "old_price": 5,
+      "initial_price": 5,
       "target_price": 4,
       "smoothed_price": 5,
       "final_price": 5,
-      "price_change": -1,
+      "price_change": 0,
       "matches_played": 5,
       "season_total_points": 0,
       "season_avg_points": 0,
@@ -4281,7 +4288,7 @@
       "score_basis": 0,
       "reliability_factor": 0.25,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4308,10 +4315,10 @@
       "score_basis": 33.3,
       "reliability_factor": 1,
       "adjusted_score": 33.3,
-      "percentile": 83,
+      "percentile": 82.61,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 83",
+        "Target price mapped from percentile 82.61",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -4422,10 +4429,10 @@
       "score_basis": 35.88,
       "reliability_factor": 1,
       "adjusted_score": 35.88,
-      "percentile": 86.17,
+      "percentile": 85.77,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 86.17",
+        "Target price mapped from percentile 85.77",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -4451,10 +4458,10 @@
       "score_basis": 16.2,
       "reliability_factor": 1,
       "adjusted_score": 16.2,
-      "percentile": 60.47,
+      "percentile": 59.68,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 60.47",
+        "Target price mapped from percentile 59.68",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -4480,10 +4487,10 @@
       "score_basis": 14,
       "reliability_factor": 0.75,
       "adjusted_score": 10.5,
-      "percentile": 54.15,
+      "percentile": 53.36,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.15",
+        "Target price mapped from percentile 53.36",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-11T10:00:00Z"
@@ -4509,10 +4516,10 @@
       "score_basis": 32.5,
       "reliability_factor": 1,
       "adjusted_score": 32.5,
-      "percentile": 81.82,
+      "percentile": 81.42,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 81.82",
+        "Target price mapped from percentile 81.42",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -4538,10 +4545,10 @@
       "score_basis": 17.7,
       "reliability_factor": 1,
       "adjusted_score": 17.7,
-      "percentile": 64.03,
+      "percentile": 63.24,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.03",
+        "Target price mapped from percentile 63.24",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -4567,7 +4574,7 @@
       "score_basis": 30.04,
       "reliability_factor": 1,
       "adjusted_score": 30.04,
-      "percentile": 78.66,
+      "percentile": 78.26,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4594,10 +4601,10 @@
       "score_basis": 14.4,
       "reliability_factor": 1,
       "adjusted_score": 14.4,
-      "percentile": 58.89,
+      "percentile": 58.1,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 58.89",
+        "Target price mapped from percentile 58.1",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -4623,7 +4630,7 @@
       "score_basis": 7.33,
       "reliability_factor": 0.75,
       "adjusted_score": 5.5,
-      "percentile": 47.83,
+      "percentile": 47.04,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4650,7 +4657,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4678,7 +4685,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4706,7 +4713,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4734,7 +4741,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4762,7 +4769,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4790,7 +4797,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4818,7 +4825,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4846,7 +4853,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4874,7 +4881,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4902,7 +4909,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4930,7 +4937,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4958,7 +4965,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4986,7 +4993,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5077,6 +5084,35 @@
       "last_match_played_at_utc": "2026-04-12T14:00:00Z"
     },
     {
+      "player_id": "rcb_phil-salt",
+      "name": "Phil Salt",
+      "team": "RCB",
+      "role": "wicket_keeper",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 8,
+      "initial_price": 8,
+      "target_price": 9,
+      "smoothed_price": 9,
+      "final_price": 9,
+      "price_change": 1,
+      "matches_played": 5,
+      "season_total_points": 210,
+      "season_avg_points": 42,
+      "recent_avg_points": 39.33,
+      "last_match_points": 17,
+      "score_basis": 40.4,
+      "reliability_factor": 1,
+      "adjusted_score": 40.4,
+      "percentile": 90.12,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Recovered real match history from a previously blank price; used the corrected target price immediately",
+        "Target price mapped from percentile 90.12"
+      ],
+      "last_match_played_at_utc": "2026-04-15T14:00:00Z"
+    },
+    {
       "player_id": "rcb_rajat-patidar",
       "name": "Rajat Patidar",
       "team": "RCB",
@@ -5126,10 +5162,10 @@
       "score_basis": 22.44,
       "reliability_factor": 1,
       "adjusted_score": 22.44,
-      "percentile": 69.57,
+      "percentile": 69.17,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 69.57",
+        "Target price mapped from percentile 69.17",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -5143,7 +5179,7 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
@@ -5155,9 +5191,11 @@
       "score_basis": 31.44,
       "reliability_factor": 1,
       "adjusted_score": 31.44,
-      "percentile": 80.24,
+      "percentile": 79.84,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 79.84",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
     },
@@ -5182,7 +5220,7 @@
       "score_basis": 31.17,
       "reliability_factor": 0.75,
       "adjusted_score": 23.38,
-      "percentile": 70.36,
+      "percentile": 69.96,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5209,10 +5247,10 @@
       "score_basis": 37.44,
       "reliability_factor": 1,
       "adjusted_score": 37.44,
-      "percentile": 88.54,
+      "percentile": 88.14,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 88.54",
+        "Target price mapped from percentile 88.14",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -5238,41 +5276,13 @@
       "score_basis": 38.56,
       "reliability_factor": 1,
       "adjusted_score": 38.56,
-      "percentile": 89.33,
+      "percentile": 88.93,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 89.33",
+        "Target price mapped from percentile 88.93",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
-    },
-    {
-      "player_id": "rcb_phil-salt",
-      "name": "Phil Salt",
-      "team": "RCB",
-      "role": "wicket_keeper",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 8,
-      "initial_price": 8,
-      "target_price": 5,
-      "smoothed_price": 8,
-      "final_price": 8,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_total_points": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 22.33,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
     },
     {
       "player_id": "rcb_rasikh-dar",
@@ -5295,10 +5305,10 @@
       "score_basis": 72.5,
       "reliability_factor": 0.5,
       "adjusted_score": 36.25,
-      "percentile": 86.96,
+      "percentile": 86.56,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 86.96",
+        "Target price mapped from percentile 86.56",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -5324,7 +5334,7 @@
       "score_basis": 24.2,
       "reliability_factor": 1,
       "adjusted_score": 24.2,
-      "percentile": 70.75,
+      "percentile": 70.36,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5351,10 +5361,10 @@
       "score_basis": 20.04,
       "reliability_factor": 1,
       "adjusted_score": 20.04,
-      "percentile": 67.19,
+      "percentile": 66.8,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 67.19",
+        "Target price mapped from percentile 66.8",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
@@ -5380,7 +5390,7 @@
       "score_basis": 34,
       "reliability_factor": 0.5,
       "adjusted_score": 17,
-      "percentile": 63.04,
+      "percentile": 62.25,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5407,7 +5417,7 @@
       "score_basis": 41,
       "reliability_factor": 0.25,
       "adjusted_score": 10.25,
-      "percentile": 53.75,
+      "percentile": 52.96,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5434,10 +5444,10 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 46.25,
+      "percentile": 45.45,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 46.25",
+        "Target price mapped from percentile 45.45",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T14:00:00Z"
@@ -5463,7 +5473,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5491,7 +5501,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5519,7 +5529,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5547,7 +5557,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5575,7 +5585,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5603,7 +5613,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5631,7 +5641,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5659,7 +5669,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5687,7 +5697,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5742,10 +5752,10 @@
       "score_basis": 36.68,
       "reliability_factor": 1,
       "adjusted_score": 36.68,
-      "percentile": 87.75,
+      "percentile": 87.35,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 87.75",
+        "Target price mapped from percentile 87.35",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -5798,7 +5808,7 @@
       "score_basis": 34.96,
       "reliability_factor": 1,
       "adjusted_score": 34.96,
-      "percentile": 85.38,
+      "percentile": 84.98,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5853,10 +5863,10 @@
       "score_basis": 35,
       "reliability_factor": 0.5,
       "adjusted_score": 17.5,
-      "percentile": 63.64,
+      "percentile": 62.85,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 63.64",
+        "Target price mapped from percentile 62.85",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-10T14:00:00Z"
@@ -5882,10 +5892,10 @@
       "score_basis": 16.44,
       "reliability_factor": 1,
       "adjusted_score": 16.44,
-      "percentile": 61.26,
+      "percentile": 60.47,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 61.26",
+        "Target price mapped from percentile 60.47",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -5911,7 +5921,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5939,10 +5949,10 @@
       "score_basis": 34.2,
       "reliability_factor": 1,
       "adjusted_score": 34.2,
-      "percentile": 84.39,
+      "percentile": 83.99,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 84.39",
+        "Target price mapped from percentile 83.99",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -5968,7 +5978,7 @@
       "score_basis": 20.36,
       "reliability_factor": 1,
       "adjusted_score": 20.36,
-      "percentile": 67.98,
+      "percentile": 67.59,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5995,7 +6005,7 @@
       "score_basis": 19.88,
       "reliability_factor": 1,
       "adjusted_score": 19.88,
-      "percentile": 66.4,
+      "percentile": 66.01,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6022,10 +6032,10 @@
       "score_basis": 21.67,
       "reliability_factor": 0.75,
       "adjusted_score": 16.25,
-      "percentile": 60.87,
+      "percentile": 60.08,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 60.87",
+        "Target price mapped from percentile 60.08",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-10T14:00:00Z"
@@ -6051,7 +6061,7 @@
       "score_basis": 34,
       "reliability_factor": 0.75,
       "adjusted_score": 25.5,
-      "percentile": 72.73,
+      "percentile": 72.33,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6078,10 +6088,10 @@
       "score_basis": 34.67,
       "reliability_factor": 0.75,
       "adjusted_score": 26,
-      "percentile": 74.7,
+      "percentile": 74.31,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 74.7",
+        "Target price mapped from percentile 74.31",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -6107,7 +6117,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6135,7 +6145,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6163,7 +6173,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6191,7 +6201,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6219,7 +6229,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6247,7 +6257,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6275,7 +6285,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6303,7 +6313,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6331,7 +6341,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6359,7 +6369,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6387,7 +6397,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6469,7 +6479,7 @@
       "score_basis": 33.52,
       "reliability_factor": 1,
       "adjusted_score": 33.52,
-      "percentile": 83.79,
+      "percentile": 83.4,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6496,10 +6506,10 @@
       "score_basis": 24.84,
       "reliability_factor": 1,
       "adjusted_score": 24.84,
-      "percentile": 72.33,
+      "percentile": 71.94,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 72.33",
+        "Target price mapped from percentile 71.94",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -6554,7 +6564,7 @@
       "score_basis": 31.55,
       "reliability_factor": 1,
       "adjusted_score": 31.55,
-      "percentile": 80.63,
+      "percentile": 80.24,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6581,10 +6591,10 @@
       "score_basis": 120,
       "reliability_factor": 0.25,
       "adjusted_score": 30,
-      "percentile": 78.26,
+      "percentile": 77.87,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 78.26",
+        "Target price mapped from percentile 77.87",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -6610,10 +6620,10 @@
       "score_basis": 117,
       "reliability_factor": 0.25,
       "adjusted_score": 29.25,
-      "percentile": 77.47,
+      "percentile": 77.08,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 77.47",
+        "Target price mapped from percentile 77.08",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -6639,10 +6649,10 @@
       "score_basis": 23.04,
       "reliability_factor": 1,
       "adjusted_score": 23.04,
-      "percentile": 69.96,
+      "percentile": 69.57,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 69.96",
+        "Target price mapped from percentile 69.57",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -6668,10 +6678,10 @@
       "score_basis": 15.52,
       "reliability_factor": 1,
       "adjusted_score": 15.52,
-      "percentile": 59.68,
+      "percentile": 58.89,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 59.68",
+        "Target price mapped from percentile 58.89",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -6697,10 +6707,10 @@
       "score_basis": 24.25,
       "reliability_factor": 0.5,
       "adjusted_score": 12.13,
-      "percentile": 56.13,
+      "percentile": 55.34,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.13",
+        "Target price mapped from percentile 55.34",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T14:00:00Z"
@@ -6726,10 +6736,10 @@
       "score_basis": 18.36,
       "reliability_factor": 1,
       "adjusted_score": 18.36,
-      "percentile": 64.43,
+      "percentile": 63.64,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.43",
+        "Target price mapped from percentile 63.64",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00Z"
@@ -6755,10 +6765,10 @@
       "score_basis": 27,
       "reliability_factor": 0.25,
       "adjusted_score": 6.75,
-      "percentile": 50.2,
+      "percentile": 49.41,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 50.2",
+        "Target price mapped from percentile 49.41",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T10:00:00Z"
@@ -6784,7 +6794,7 @@
       "score_basis": 30.5,
       "reliability_factor": 1,
       "adjusted_score": 30.5,
-      "percentile": 79.05,
+      "percentile": 78.66,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6811,7 +6821,7 @@
       "score_basis": 3.5,
       "reliability_factor": 0.75,
       "adjusted_score": 2.63,
-      "percentile": 47.04,
+      "percentile": 46.25,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6838,7 +6848,7 @@
       "score_basis": 16.7,
       "reliability_factor": 1,
       "adjusted_score": 16.7,
-      "percentile": 61.66,
+      "percentile": 60.87,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6865,7 +6875,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6893,7 +6903,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6921,7 +6931,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6949,7 +6959,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6977,7 +6987,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7005,7 +7015,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7033,7 +7043,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7061,7 +7071,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7089,7 +7099,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7117,7 +7127,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7145,7 +7155,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 22.33,
+      "percentile": 21.94,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"

--- a/data/mini_fantasy_prices.json
+++ b/data/mini_fantasy_prices.json
@@ -17,9 +17,9 @@
   "summary": {
     "total_players_received": 254,
     "eligible_players_ranked": 254,
-    "price_rises": 1,
+    "price_rises": 0,
     "price_drops": 1,
-    "price_unchanged": 252
+    "price_unchanged": 253
   },
   "players": [
     {
@@ -297,7 +297,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -408,7 +408,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -575,7 +575,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -603,7 +603,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -631,7 +631,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -659,7 +659,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -687,7 +687,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -715,7 +715,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1039,12 +1039,12 @@
       "role": "bowler",
       "is_uncapped": false,
       "pricing_eligible": true,
-      "old_price": 8,
-      "initial_price": 8,
+      "old_price": 7,
+      "initial_price": 7,
       "target_price": 7,
       "smoothed_price": 7,
       "final_price": 7,
-      "price_change": -1,
+      "price_change": 0,
       "matches_played": 4,
       "season_total_points": 115,
       "season_avg_points": 28.75,
@@ -1055,9 +1055,7 @@
       "adjusted_score": 19.7,
       "percentile": 64.82,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Recovered real match history from a previously blank price; used the corrected target price immediately",
-        "Target price mapped from percentile 64.82"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-11T14:00:00Z"
     },
@@ -1136,7 +1134,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1164,7 +1162,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1192,7 +1190,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1220,7 +1218,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1248,7 +1246,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1276,7 +1274,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1304,7 +1302,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1332,7 +1330,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1360,7 +1358,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1388,7 +1386,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1416,7 +1414,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1811,7 +1809,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1839,7 +1837,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1867,7 +1865,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1895,7 +1893,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1923,7 +1921,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1951,7 +1949,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -1979,7 +1977,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2007,7 +2005,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2035,7 +2033,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2063,7 +2061,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2091,7 +2089,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2119,7 +2117,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2539,7 +2537,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2567,7 +2565,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2595,7 +2593,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2623,7 +2621,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2651,7 +2649,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2679,7 +2677,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2707,7 +2705,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2735,7 +2733,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2763,7 +2761,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2791,7 +2789,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -2819,10 +2817,10 @@
       "score_basis": -5,
       "reliability_factor": 0.25,
       "adjusted_score": -1.25,
-      "percentile": 0.2,
+      "percentile": 0.4,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 0.2",
+        "Target price mapped from percentile 0.4",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-09T14:00:00Z"
@@ -3103,7 +3101,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3295,7 +3293,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3323,7 +3321,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3351,7 +3349,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3379,7 +3377,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3407,7 +3405,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3435,7 +3433,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3463,7 +3461,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3491,7 +3489,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3519,7 +3517,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -3547,10 +3545,10 @@
       "score_basis": -5,
       "reliability_factor": 0.25,
       "adjusted_score": -1.25,
-      "percentile": 0.2,
+      "percentile": 0.4,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 0.2",
+        "Target price mapped from percentile 0.4",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-01T14:00:00Z"
@@ -3866,7 +3864,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4006,7 +4004,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4034,7 +4032,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4062,7 +4060,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4090,7 +4088,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4118,7 +4116,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4146,7 +4144,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4174,7 +4172,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4231,7 +4229,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4259,10 +4257,10 @@
       "score_basis": -0.4,
       "reliability_factor": 1,
       "adjusted_score": -0.4,
-      "percentile": 0.79,
+      "percentile": 1.19,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 0.79",
+        "Target price mapped from percentile 1.19",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00Z"
@@ -4288,7 +4286,7 @@
       "score_basis": 0,
       "reliability_factor": 0.25,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4657,7 +4655,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4685,7 +4683,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4713,7 +4711,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4741,7 +4739,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4769,7 +4767,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4797,7 +4795,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4825,7 +4823,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4853,7 +4851,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4881,7 +4879,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4909,7 +4907,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4937,7 +4935,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4965,7 +4963,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -4993,7 +4991,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5090,12 +5088,12 @@
       "role": "wicket_keeper",
       "is_uncapped": false,
       "pricing_eligible": true,
-      "old_price": 8,
-      "initial_price": 8,
+      "old_price": 9,
+      "initial_price": 9,
       "target_price": 9,
       "smoothed_price": 9,
       "final_price": 9,
-      "price_change": 1,
+      "price_change": 0,
       "matches_played": 5,
       "season_total_points": 210,
       "season_avg_points": 42,
@@ -5106,9 +5104,7 @@
       "adjusted_score": 40.4,
       "percentile": 90.12,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Recovered real match history from a previously blank price; used the corrected target price immediately",
-        "Target price mapped from percentile 90.12"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00Z"
     },
@@ -5473,7 +5469,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5501,7 +5497,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5529,7 +5525,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5557,7 +5553,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5585,7 +5581,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5613,7 +5609,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5641,7 +5637,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5669,7 +5665,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5697,7 +5693,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -5921,7 +5917,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6117,7 +6113,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6145,7 +6141,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6173,7 +6169,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6201,7 +6197,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6229,35 +6225,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
-      "calculation_notes": [
-        "Used old_price for smoothing",
-        "No matches played; retained base price"
-      ],
-      "last_match_played_at_utc": null
-    },
-    {
-      "player_id": "rr_lhuan-dre-pretorious",
-      "name": "Lhuan-dre Pretorious",
-      "team": "RR",
-      "role": "wicket_keeper",
-      "is_uncapped": false,
-      "pricing_eligible": true,
-      "old_price": 6,
-      "initial_price": 6,
-      "target_price": 5,
-      "smoothed_price": 6,
-      "final_price": 6,
-      "price_change": 0,
-      "matches_played": 0,
-      "season_total_points": 0,
-      "season_avg_points": 0,
-      "recent_avg_points": 0,
-      "last_match_points": 0,
-      "score_basis": 0,
-      "reliability_factor": 0,
-      "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6285,7 +6253,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6313,7 +6281,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6341,7 +6309,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6369,7 +6337,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6397,12 +6365,41 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
       ],
       "last_match_played_at_utc": null
+    },
+    {
+      "player_id": "rr_lhuan-dre-pretorious",
+      "name": "Lhuan-dre Pretorious",
+      "team": "RR",
+      "role": "wicket_keeper",
+      "is_uncapped": false,
+      "pricing_eligible": true,
+      "old_price": 6,
+      "initial_price": 6,
+      "target_price": 4,
+      "smoothed_price": 4,
+      "final_price": 4,
+      "price_change": -2,
+      "matches_played": 1,
+      "season_total_points": -5,
+      "season_avg_points": -5,
+      "recent_avg_points": -5,
+      "last_match_points": -5,
+      "score_basis": -5,
+      "reliability_factor": 0.25,
+      "adjusted_score": -1.25,
+      "percentile": 0.4,
+      "calculation_notes": [
+        "Used old_price for smoothing",
+        "Recovered real match history from a previously blank price; used the corrected target price immediately",
+        "Target price mapped from percentile 0.4"
+      ],
+      "last_match_played_at_utc": "2026-04-13T14:00:00Z"
     },
     {
       "player_id": "srh_heinrich-klaasen",
@@ -6875,7 +6872,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6903,7 +6900,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6931,7 +6928,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6959,7 +6956,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -6987,7 +6984,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7015,7 +7012,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7043,7 +7040,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7071,7 +7068,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7099,7 +7096,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7127,7 +7124,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"
@@ -7155,7 +7152,7 @@
       "score_basis": 0,
       "reliability_factor": 0,
       "adjusted_score": 0,
-      "percentile": 21.94,
+      "percentile": 22.13,
       "calculation_notes": [
         "Used old_price for smoothing",
         "No matches played; retained base price"

--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -191,6 +191,12 @@ const EXPLICIT_NAME_ALIASES = Object.freeze({
   'philip salt': Object.freeze([
     'phil salt'
   ]),
+  'lhuan dre pretorious': Object.freeze([
+    'lhuan dre pretorius'
+  ]),
+  'lhuan dre pretorius': Object.freeze([
+    'lhuan dre pretorious'
+  ]),
   'lungi ngidi': Object.freeze([
     'lungisani ngidi'
   ]),

--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -185,6 +185,18 @@ const NAME_TOKEN_EXPANSIONS = Object.freeze({
 });
 
 const EXPLICIT_NAME_ALIASES = Object.freeze({
+  'phil salt': Object.freeze([
+    'philip salt'
+  ]),
+  'philip salt': Object.freeze([
+    'phil salt'
+  ]),
+  'lungi ngidi': Object.freeze([
+    'lungisani ngidi'
+  ]),
+  'lungisani ngidi': Object.freeze([
+    'lungi ngidi'
+  ]),
   'allah ghazanfar': Object.freeze([
     'am ghazanfar',
     'allah mohammad ghazanfar',

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -95,7 +95,9 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                   'Tilak Varma': 1,
                   'Vaibhav Sooryavanshi': 1,
                   'Suryakumar Yadav': 1,
-                  'AM Ghazanfar': 1
+                  'AM Ghazanfar': 1,
+                  'Philip Salt': 1,
+                  'Lungi Ngidi': 1
                 }
               }
             },
@@ -108,7 +110,9 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                 'Tilak Varma': { score: 15 },
                 'Vaibhav Sooryavanshi': { score: 52 },
                 'Suryakumar Yadav': { score: 33 },
-                'AM Ghazanfar': { score: 44 }
+                'AM Ghazanfar': { score: 44 },
+                'Philip Salt': { score: 49 },
+                'Lungi Ngidi': { score: 28 }
               }
             }
           }
@@ -126,7 +130,10 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                   'Tilak Varma': 2,
                   'Vaibhav Sooryavanshi': 1,
                   'Suryakumar Yadav': 2,
-                  'AM Ghazanfar': 2
+                  'AM Ghazanfar': 2,
+                  'Philip Salt': 2,
+                  'Lungisani Ngidi': 1,
+                  'Lungi Ngidi': 1
                 }
               }
             },
@@ -139,7 +146,10 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                 'Tilak Varma': { score: 25 },
                 'Vaibhav Sooryavanshi': { score: 52 },
                 'Suryakumar Yadav': { score: 83 },
-                'AM Ghazanfar': { score: 96 }
+                'AM Ghazanfar': { score: 96 },
+                'Philip Salt': { score: 67 },
+                'Lungisani Ngidi': { score: 51 },
+                'Lungi Ngidi': { score: 79 }
               }
             }
           }
@@ -161,6 +171,8 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
   assert.deepEqual(resolvePlayerHistory('Vaibhav Suryavanshi', histories)?.match_points, [52]);
   assert.deepEqual(resolvePlayerHistory('Surya Kumar Yadav', histories)?.match_points, [33, 50]);
   assert.deepEqual(resolvePlayerHistory('Allah Ghazanfar', histories)?.match_points, [44, 52]);
+  assert.deepEqual(resolvePlayerHistory('Phil Salt', histories)?.match_points, [49, 18]);
+  assert.deepEqual(resolvePlayerHistory('Lungisani Ngidi', histories)?.match_points, [28, 51]);
 });
 
 test('buildMiniFantasyPlayerPointsIndex keeps completed fixture points for Surya Kumar Yadav aliases', () => {
@@ -582,6 +594,89 @@ test('generateMiniFantasyPriceBook matches Allah Ghazanfar against AM Ghazanfar 
   assert.equal(player.season_total_points, 96);
   assert.equal(player.last_match_points, 52);
   assert.equal(player.final_price > 6, true);
+});
+
+test('generateMiniFantasyPriceBook matches Phil Salt and Lungisani Ngidi against split history aliases', () => {
+  const liveData = {
+    fetchedAt: '2026-04-18T00:10:00Z',
+    meta: {
+      scoreHistory: [
+        {
+          processedMatchCount: 1,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Philip Salt': 1,
+                  'Lungi Ngidi': 1
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Philip Salt': { score: 49 },
+                'Lungi Ngidi': { score: 28 }
+              }
+            }
+          }
+        },
+        {
+          processedMatchCount: 2,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Philip Salt': 2,
+                  'Lungi Ngidi': 1,
+                  'Lungisani Ngidi': 1
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Philip Salt': { score: 67 },
+                'Lungi Ngidi': { score: 28 },
+                'Lungisani Ngidi': { score: 51 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  };
+  const schedule = [
+    { match_no: 1, datetime_utc: '2026-04-17T14:00:00Z' },
+    { match_no: 2, datetime_utc: '2026-04-18T14:00:00Z' }
+  ];
+  const squads = {
+    RCB: ['Phil Salt'],
+    DC: ['Lungisani Ngidi']
+  };
+  const teamRoles = {
+    teams: {
+      RCB: { players: { 'Phil Salt': 'wicket_keeper' } },
+      DC: { players: { 'Lungisani Ngidi': 'bowler' } }
+    }
+  };
+
+  const priceBook = generateMiniFantasyPriceBook({
+    liveData,
+    schedule,
+    squads,
+    teamRoles,
+    asOfUtc: '2026-04-18T00:10:00Z'
+  });
+
+  const salt = priceBook.players.find((entry) => entry.name === 'Phil Salt');
+  const ngidi = priceBook.players.find((entry) => entry.name === 'Lungisani Ngidi');
+  assert.ok(salt);
+  assert.equal(salt.matches_played, 2);
+  assert.equal(salt.season_total_points, 67);
+  assert.equal(salt.last_match_points, 18);
+  assert.ok(ngidi);
+  assert.equal(ngidi.matches_played, 2);
+  assert.equal(ngidi.season_total_points, 79);
+  assert.equal(ngidi.last_match_points, 51);
 });
 
 test('generateMiniFantasyPriceBook marks uncapped players and caps them at 9 credits', () => {

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -97,7 +97,8 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                   'Suryakumar Yadav': 1,
                   'AM Ghazanfar': 1,
                   'Philip Salt': 1,
-                  'Lungi Ngidi': 1
+                  'Lungi Ngidi': 1,
+                  'Lhuan-dre Pretorius': 1
                 }
               }
             },
@@ -112,7 +113,8 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                 'Suryakumar Yadav': { score: 33 },
                 'AM Ghazanfar': { score: 44 },
                 'Philip Salt': { score: 49 },
-                'Lungi Ngidi': { score: 28 }
+                'Lungi Ngidi': { score: 28 },
+                'Lhuan-dre Pretorius': { score: 35 }
               }
             }
           }
@@ -133,7 +135,8 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                   'AM Ghazanfar': 2,
                   'Philip Salt': 2,
                   'Lungisani Ngidi': 1,
-                  'Lungi Ngidi': 1
+                  'Lungi Ngidi': 1,
+                  'Lhuan-dre Pretorius': 2
                 }
               }
             },
@@ -149,7 +152,8 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
                 'AM Ghazanfar': { score: 96 },
                 'Philip Salt': { score: 67 },
                 'Lungisani Ngidi': { score: 51 },
-                'Lungi Ngidi': { score: 79 }
+                'Lungi Ngidi': { score: 79 },
+                'Lhuan-dre Pretorius': { score: 80 }
               }
             }
           }
@@ -173,6 +177,7 @@ test('resolvePlayerHistory matches safe alias variations used by squad lists', (
   assert.deepEqual(resolvePlayerHistory('Allah Ghazanfar', histories)?.match_points, [44, 52]);
   assert.deepEqual(resolvePlayerHistory('Phil Salt', histories)?.match_points, [49, 18]);
   assert.deepEqual(resolvePlayerHistory('Lungisani Ngidi', histories)?.match_points, [28, 51]);
+  assert.deepEqual(resolvePlayerHistory('Lhuan-dre Pretorious', histories)?.match_points, [35, 45]);
 });
 
 test('buildMiniFantasyPlayerPointsIndex keeps completed fixture points for Surya Kumar Yadav aliases', () => {
@@ -677,6 +682,76 @@ test('generateMiniFantasyPriceBook matches Phil Salt and Lungisani Ngidi against
   assert.equal(ngidi.matches_played, 2);
   assert.equal(ngidi.season_total_points, 79);
   assert.equal(ngidi.last_match_points, 51);
+});
+
+test('generateMiniFantasyPriceBook matches Lhuan-dre Pretorious against Pretorius history', () => {
+  const liveData = {
+    fetchedAt: '2026-04-18T00:10:00Z',
+    meta: {
+      scoreHistory: [
+        {
+          processedMatchCount: 1,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Lhuan-dre Pretorius': 1
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Lhuan-dre Pretorius': { score: 35 }
+              }
+            }
+          }
+        },
+        {
+          processedMatchCount: 2,
+          snapshot: {
+            meta: {
+              aggregates: {
+                playerMatches: {
+                  'Lhuan-dre Pretorius': 2
+                }
+              }
+            },
+            mvp: {
+              values: {
+                'Lhuan-dre Pretorius': { score: 80 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  };
+  const schedule = [
+    { match_no: 1, datetime_utc: '2026-04-17T14:00:00Z' },
+    { match_no: 2, datetime_utc: '2026-04-18T14:00:00Z' }
+  ];
+  const squads = {
+    RR: ['Lhuan-dre Pretorious']
+  };
+  const teamRoles = {
+    teams: {
+      RR: { players: { 'Lhuan-dre Pretorius': 'wicket_keeper' } }
+    }
+  };
+
+  const priceBook = generateMiniFantasyPriceBook({
+    liveData,
+    schedule,
+    squads,
+    teamRoles,
+    asOfUtc: '2026-04-18T00:10:00Z'
+  });
+
+  const pretorious = priceBook.players.find((entry) => entry.name === 'Lhuan-dre Pretorious');
+  assert.ok(pretorious);
+  assert.equal(pretorious.matches_played, 2);
+  assert.equal(pretorious.season_total_points, 80);
+  assert.equal(pretorious.last_match_points, 45);
 });
 
 test('generateMiniFantasyPriceBook marks uncapped players and caps them at 9 credits', () => {


### PR DESCRIPTION
## Summary
- fix Mini Fantasy history matching for Phil Salt vs Philip Salt
- fix Mini Fantasy history matching for Lungisani Ngidi vs Lungi Ngidi
- fix Mini Fantasy history matching for Lhuan-dre Pretorious vs Lhuan-dre Pretorius
- regenerate the Mini Fantasy price book so picker totals and last-match points reflect the repaired aliases
- add regression tests covering all three alias cases

## Validation
- node test suite passed locally: 94/94

## Notes
- this keeps the current player ids stable and only repairs alias resolution, so existing saved picks are not remapped