### PR TITLE
feat: precompute mini fantasy leaderboard snapshots

### DIFF
--- a/.github/workflows/update-live-data.yml
+++ b/.github/workflows/update-live-data.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Refresh Mini Fantasy prices
         run: node scripts/update-mini-fantasy-prices.mjs
 
+      - name: Publish Mini Fantasy leaderboard snapshot
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: node scripts/publish-mini-fantasy-leaderboard.mjs
+
       - name: Commit live data
         shell: bash
         run: |

--- a/docs/DUELS_BACKEND_SETUP.md
+++ b/docs/DUELS_BACKEND_SETUP.md
@@ -51,7 +51,7 @@ Once configured:
 - public duel browsing reads directly from backend records
 - `Mini Fantasy` saves one hosted entry per user per match
 - saved Mini Fantasy entries carry a fixture-specific price snapshot
-- Mini Fantasy leaderboard reads from the hosted Mini Fantasy entry table
+- Mini Fantasy leaderboard prefers the hosted snapshot table and falls back to hosted entry rows if the snapshot is stale or empty
 
 ## Current scope
 
@@ -62,6 +62,7 @@ The backend owns:
 - duel entries
 - Mini Fantasy match entries
 - Mini Fantasy leaderboard source rows
+- precomputed Mini Fantasy leaderboard snapshot rows
 - entry ownership
 - persisted submitted picks
 - persisted saved Mini Fantasy lineups plus captain choice
@@ -82,8 +83,20 @@ If you already ran the SQL once before Mini Fantasy leaderboard support landed, 
 That refresh keeps:
 
 - `mini_fantasy_entries` present
+- `mini_fantasy_leaderboard_rows` present
 - latest insert/update lock policies in place
 - public read policy in place for the leaderboard
+
+## Optional leaderboard publishing
+
+The site can fall back to client-side leaderboard computation, but the faster path is a precomputed snapshot written to Supabase by the live-data workflow.
+
+To enable that publisher in GitHub Actions, add:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+The service-role key is only for the workflow publisher. Do not place it in frontend code.
 
 ## Public vs private
 

--- a/docs/duels_backend_supabase.sql
+++ b/docs/duels_backend_supabase.sql
@@ -75,6 +75,29 @@ create table if not exists public.mini_fantasy_daily_bonus_claims (
   unique (user_id, season, bonus_date_ist)
 );
 
+create table if not exists public.mini_fantasy_leaderboard_rows (
+  id uuid primary key default gen_random_uuid(),
+  season text not null,
+  owner_handle text not null,
+  user_id uuid references auth.users (id) on delete set null,
+  display_name text not null default '',
+  rank integer not null,
+  medal text,
+  total_points numeric not null default 0,
+  saved_entries integer not null default 0,
+  scored_entries integer not null default 0,
+  pending_entries integer not null default 0,
+  latest_saved_at timestamptz,
+  daily_bonus_points numeric not null default 0,
+  missed_lock_points numeric not null default 0,
+  new_player_baseline_points numeric not null default 0,
+  completed_match_count integer not null default 0,
+  matches jsonb not null default '[]'::jsonb,
+  live_data_fetched_at timestamptz,
+  generated_at timestamptz not null default timezone('utc', now()),
+  unique (season, owner_handle)
+);
+
 alter table public.mini_fantasy_entries
   add column if not exists display_name text not null default '';
 
@@ -113,6 +136,7 @@ alter table public.duels enable row level security;
 alter table public.duel_entries enable row level security;
 alter table public.mini_fantasy_entries enable row level security;
 alter table public.mini_fantasy_daily_bonus_claims enable row level security;
+alter table public.mini_fantasy_leaderboard_rows enable row level security;
 
 drop policy if exists "profiles are public readable" on public.profiles;
 create policy "profiles are public readable"
@@ -246,6 +270,12 @@ with check (
 drop policy if exists "mini fantasy daily bonuses are public readable" on public.mini_fantasy_daily_bonus_claims;
 create policy "mini fantasy daily bonuses are public readable"
 on public.mini_fantasy_daily_bonus_claims
+for select
+using (true);
+
+drop policy if exists "mini fantasy leaderboard rows are public readable" on public.mini_fantasy_leaderboard_rows;
+create policy "mini fantasy leaderboard rows are public readable"
+on public.mini_fantasy_leaderboard_rows
 for select
 using (true);
 

--- a/duels-backend.config.js
+++ b/duels-backend.config.js
@@ -9,6 +9,8 @@ window.DUELS_BACKEND_CONFIG = Object.assign({
     profiles: 'profiles',
     duels: 'duels',
     duelEntries: 'duel_entries',
-    miniFantasyEntries: 'mini_fantasy_entries'
+    miniFantasyEntries: 'mini_fantasy_entries',
+    miniFantasyDailyBonuses: 'mini_fantasy_daily_bonus_claims',
+    miniFantasyLeaderboardRows: 'mini_fantasy_leaderboard_rows'
   }
 }, window.DUELS_BACKEND_CONFIG || {});

--- a/duels-backend.js
+++ b/duels-backend.js
@@ -11,7 +11,8 @@
       duels: 'duels',
       duelEntries: 'duel_entries',
       miniFantasyEntries: 'mini_fantasy_entries',
-      miniFantasyDailyBonuses: 'mini_fantasy_daily_bonus_claims'
+      miniFantasyDailyBonuses: 'mini_fantasy_daily_bonus_claims',
+      miniFantasyLeaderboardRows: 'mini_fantasy_leaderboard_rows'
     }
   };
 
@@ -191,6 +192,7 @@
         async listPublicMiniFantasyEntries() { return []; },
         async listPublicMiniFantasyProfiles() { return []; },
         async listPublicMiniFantasyDailyBonuses() { return []; },
+        async listMiniFantasyLeaderboardRows() { return []; },
         async claimMiniFantasyDailyBonus() { throw disabledError(); },
         async upsertMiniFantasyEntry() { throw disabledError(); }
       };
@@ -461,6 +463,45 @@ function normalizeMiniFantasyEntryRow(row) {
         bonus_points: Number(row.bonus_points || 0) || 0,
         createdAt: row.created_at || null,
         created_at: row.created_at || null
+      };
+    }
+
+    function normalizeMiniFantasyLeaderboardRow(row) {
+      if (!row) return null;
+      return {
+        id: row.id || null,
+        season: normalizeWhitespace(row.season || ''),
+        ownerHandle: normalizeSlug(row.owner_handle || ''),
+        owner_handle: normalizeSlug(row.owner_handle || ''),
+        userId: row.user_id || null,
+        user_id: row.user_id || null,
+        displayName: normalizeWhitespace(row.display_name || row.owner_handle || ''),
+        display_name: normalizeWhitespace(row.display_name || row.owner_handle || ''),
+        rank: Number(row.rank || 0) || 0,
+        medal: normalizeWhitespace(row.medal || '') || null,
+        totalPoints: Number(row.total_points || 0) || 0,
+        total_points: Number(row.total_points || 0) || 0,
+        savedEntries: Number(row.saved_entries || 0) || 0,
+        saved_entries: Number(row.saved_entries || 0) || 0,
+        scoredEntries: Number(row.scored_entries || 0) || 0,
+        scored_entries: Number(row.scored_entries || 0) || 0,
+        pendingEntries: Number(row.pending_entries || 0) || 0,
+        pending_entries: Number(row.pending_entries || 0) || 0,
+        latestSavedAt: row.latest_saved_at || null,
+        latest_saved_at: row.latest_saved_at || null,
+        dailyBonusPoints: Number(row.daily_bonus_points || 0) || 0,
+        daily_bonus_points: Number(row.daily_bonus_points || 0) || 0,
+        missedLockPoints: Number(row.missed_lock_points || 0) || 0,
+        missed_lock_points: Number(row.missed_lock_points || 0) || 0,
+        newPlayerBaselinePoints: Number(row.new_player_baseline_points || 0) || 0,
+        new_player_baseline_points: Number(row.new_player_baseline_points || 0) || 0,
+        completedMatchCount: Number(row.completed_match_count || 0) || 0,
+        completed_match_count: Number(row.completed_match_count || 0) || 0,
+        matches: cloneJson(row.matches || []),
+        liveDataFetchedAt: row.live_data_fetched_at || null,
+        live_data_fetched_at: row.live_data_fetched_at || null,
+        generatedAt: row.generated_at || null,
+        generated_at: row.generated_at || null
       };
     }
 
@@ -831,6 +872,21 @@ function normalizeMiniFantasyEntryRow(row) {
           accessToken: activeSession?.access_token || currentUser?.accessToken || null
         });
         return (Array.isArray(rows) ? rows : []).map(normalizeMiniFantasyDailyBonusRow).filter(Boolean);
+      },
+
+      async listMiniFantasyLeaderboardRows({ season, currentUser } = {}) {
+        const activeSession = await ensureFreshSession();
+        const safeSeason = normalizeWhitespace(season || '');
+        const rows = await restRequest(config.tables.miniFantasyLeaderboardRows, {
+          method: 'GET',
+          query: {
+            select: 'id,season,owner_handle,user_id,display_name,rank,medal,total_points,saved_entries,scored_entries,pending_entries,latest_saved_at,daily_bonus_points,missed_lock_points,new_player_baseline_points,completed_match_count,matches,live_data_fetched_at,generated_at',
+            ...(safeSeason ? { season: `eq.${safeSeason}` } : {}),
+            order: 'rank.asc,total_points.desc'
+          },
+          accessToken: activeSession?.access_token || currentUser?.accessToken || null
+        });
+        return (Array.isArray(rows) ? rows : []).map(normalizeMiniFantasyLeaderboardRow).filter(Boolean);
       },
 
       async claimMiniFantasyDailyBonus({ currentUser, season, bonusDateIst, bonusPoints }) {

--- a/index.html
+++ b/index.html
@@ -4355,6 +4355,7 @@ function titleBandScore(pick, live){
         .filter((item) => miniFantasyEntryStoreKey(item) !== miniFantasyEntryStoreKey(entry));
       leaderboardEntries.push(cloneJson(entry));
       REMOTE_MINI_FANTASY_LEADERBOARD_ENTRIES = leaderboardEntries;
+      MINI_FANTASY_FORCE_LEADERBOARD_FALLBACK = true;
       invalidateMiniFantasyComputedData();
       return entry;
     }

--- a/index.html
+++ b/index.html
@@ -1448,11 +1448,13 @@
     let REMOTE_DUEL_STORE = { version: 1, rooms: {} };
     let REMOTE_MINI_FANTASY_ENTRIES = [];
     let REMOTE_MINI_FANTASY_LEADERBOARD_ENTRIES = [];
+    let REMOTE_MINI_FANTASY_LEADERBOARD_ROWS = [];
     let REMOTE_MINI_FANTASY_PROFILES = [];
     let REMOTE_MINI_FANTASY_DAILY_BONUSES = [];
     let MINI_FANTASY_PUBLIC_DATA_STATUS = 'idle';
     let MINI_FANTASY_PUBLIC_DATA_PROMISE = null;
     let MINI_FANTASY_DAILY_BONUS_TABLE_AVAILABLE = true;
+    let MINI_FANTASY_FORCE_LEADERBOARD_FALLBACK = false;
     let MINI_FANTASY_COMPUTE_REVISION = 0;
     let MINI_FANTASY_LEADERBOARD_CACHE = { key: '', value: null };
     let MINI_FANTASY_RECENT_BOARD_CACHE = { key: '', value: null };
@@ -4274,7 +4276,7 @@ function titleBandScore(pick, live){
     function queueMiniFantasyPublicDataLoad({ force = false } = {}){
       if (!usesHostedDuelsBackend() || activeView !== 'fantasy') return Promise.resolve([]);
       if (!force && (MINI_FANTASY_PUBLIC_DATA_STATUS === 'loading' || MINI_FANTASY_PUBLIC_DATA_STATUS === 'ready')) {
-        return MINI_FANTASY_PUBLIC_DATA_PROMISE || Promise.resolve(currentMiniFantasyLeaderboardEntries());
+        return MINI_FANTASY_PUBLIC_DATA_PROMISE || Promise.resolve(currentMiniFantasyLeaderboardRows());
       }
       MINI_FANTASY_PUBLIC_DATA_STATUS = 'loading';
       MINI_FANTASY_PUBLIC_DATA_PROMISE = Promise.resolve().then(() => syncMiniFantasyEntries({
@@ -4288,7 +4290,7 @@ function titleBandScore(pick, live){
       }).catch((error) => {
         MINI_FANTASY_PUBLIC_DATA_STATUS = 'error';
         console.warn('Mini Fantasy public leaderboard sync skipped:', error);
-        return currentMiniFantasyLeaderboardEntries();
+        return currentMiniFantasyLeaderboardRows();
       }).finally(() => {
         MINI_FANTASY_PUBLIC_DATA_PROMISE = null;
         if (activeView === 'fantasy') {
@@ -4308,6 +4310,13 @@ function titleBandScore(pick, live){
       REMOTE_MINI_FANTASY_LEADERBOARD_ENTRIES = Array.isArray(entries) ? cloneJson(entries) : [];
       invalidateMiniFantasyComputedData();
       return REMOTE_MINI_FANTASY_LEADERBOARD_ENTRIES;
+    }
+
+    function setRemoteMiniFantasyLeaderboardRows(rows = []){
+      REMOTE_MINI_FANTASY_LEADERBOARD_ROWS = Array.isArray(rows) ? cloneJson(rows) : [];
+      MINI_FANTASY_FORCE_LEADERBOARD_FALLBACK = false;
+      invalidateMiniFantasyComputedData();
+      return REMOTE_MINI_FANTASY_LEADERBOARD_ROWS;
     }
 
     function setRemoteMiniFantasyProfiles(profiles = []){
@@ -4331,6 +4340,7 @@ function titleBandScore(pick, live){
           && normalizeTextValue(item.bonusDateIst || item.bonus_date_ist || item.dateKey || '') === safeDateKey));
       nextBonuses.push(cloneJson(bonus));
       REMOTE_MINI_FANTASY_DAILY_BONUSES = nextBonuses;
+      MINI_FANTASY_FORCE_LEADERBOARD_FALLBACK = true;
       invalidateMiniFantasyComputedData();
       return bonus;
     }
@@ -4361,6 +4371,10 @@ function titleBandScore(pick, live){
       return usesHostedDuelsBackend()
         ? (REMOTE_MINI_FANTASY_LEADERBOARD_ENTRIES || [])
         : loadStoredMiniFantasyEntriesStore().entries;
+    }
+
+    function currentMiniFantasyLeaderboardRows(){
+      return usesHostedDuelsBackend() ? (REMOTE_MINI_FANTASY_LEADERBOARD_ROWS || []) : [];
     }
 
     function currentMiniFantasyProfiles(){
@@ -4403,7 +4417,7 @@ function titleBandScore(pick, live){
       }
       try {
         const shouldLoadDailyBonuses = includeDailyBonuses && MINI_FANTASY_DAILY_BONUS_TABLE_AVAILABLE;
-        const [entries, leaderboardEntries, profiles, dailyBonuses] = await Promise.all([
+        const [entries, leaderboardEntries, leaderboardRows, profiles, dailyBonuses] = await Promise.all([
           CURRENT_USER
             ? DUELS_BACKEND.listMiniFantasyEntries({
                 season: MINI_FANTASY_SEASON,
@@ -4416,6 +4430,15 @@ function titleBandScore(pick, live){
                 currentUser: CURRENT_USER
               })
             : Promise.resolve(REMOTE_MINI_FANTASY_LEADERBOARD_ENTRIES || []),
+          includePublicData
+            ? DUELS_BACKEND.listMiniFantasyLeaderboardRows({
+                season: MINI_FANTASY_SEASON,
+                currentUser: CURRENT_USER
+              }).catch((error) => {
+                console.warn('Hosted mini fantasy leaderboard snapshot load failed:', error);
+                return REMOTE_MINI_FANTASY_LEADERBOARD_ROWS || [];
+              })
+            : Promise.resolve(REMOTE_MINI_FANTASY_LEADERBOARD_ROWS || []),
           includeProfiles
             ? DUELS_BACKEND.listPublicMiniFantasyProfiles({
                 currentUser: CURRENT_USER
@@ -4438,6 +4461,7 @@ function titleBandScore(pick, live){
         ]);
         setRemoteMiniFantasyEntries(entries || []);
         if (includePublicData) setRemoteMiniFantasyLeaderboardEntries(leaderboardEntries || []);
+        if (includePublicData) setRemoteMiniFantasyLeaderboardRows(leaderboardRows || []);
         if (includeProfiles) setRemoteMiniFantasyProfiles(profiles || []);
         if (shouldLoadDailyBonuses) setRemoteMiniFantasyDailyBonuses(dailyBonuses || []);
       } catch (error) {
@@ -4449,6 +4473,7 @@ function titleBandScore(pick, live){
         };
         setRemoteMiniFantasyEntries([]);
         if (includePublicData) setRemoteMiniFantasyLeaderboardEntries([]);
+        if (includePublicData) setRemoteMiniFantasyLeaderboardRows([]);
         if (includeProfiles) setRemoteMiniFantasyProfiles([]);
         if (shouldLoadDailyBonuses) setRemoteMiniFantasyDailyBonuses([]);
       }
@@ -8554,10 +8579,27 @@ function titleBandScore(pick, live){
         MINI_FANTASY_COMPUTE_REVISION,
         LIVE_2026?.fetchedAt || '',
         Number(LIVE_2026?.meta?.scoreHistory?.length || 0),
-        Number(LEAGUE_STAGE_SCHEDULE?.length || 0)
+        Number(LEAGUE_STAGE_SCHEDULE?.length || 0),
+        MINI_FANTASY_FORCE_LEADERBOARD_FALLBACK ? 'fallback' : 'snapshot'
       ].join('|');
       if (MINI_FANTASY_LEADERBOARD_CACHE.key === cacheKey && MINI_FANTASY_LEADERBOARD_CACHE.value) {
         return MINI_FANTASY_LEADERBOARD_CACHE.value;
+      }
+      const liveFetchedAt = normalizeTextValue(LIVE_2026?.fetchedAt || '');
+      const leaderboardRows = currentMiniFantasyLeaderboardRows();
+      const canUsePrecomputedRows = usesHostedDuelsBackend()
+        && !MINI_FANTASY_FORCE_LEADERBOARD_FALLBACK
+        && liveFetchedAt
+        && Array.isArray(leaderboardRows)
+        && leaderboardRows.length
+        && leaderboardRows.every((row) => normalizeTextValue(row.liveDataFetchedAt || row.live_data_fetched_at || '') === liveFetchedAt);
+      if (canUsePrecomputedRows) {
+        const value = {
+          completed_match_count: Number(leaderboardRows[0]?.completedMatchCount || leaderboardRows[0]?.completed_match_count || 0) || 0,
+          rows: cloneJson(leaderboardRows)
+        };
+        MINI_FANTASY_LEADERBOARD_CACHE = { key: cacheKey, value };
+        return value;
       }
       const value = buildMiniFantasyLeaderboard({
         entries: currentMiniFantasyLeaderboardEntries(),
@@ -9730,6 +9772,7 @@ function titleBandScore(pick, live){
       REMOTE_DUEL_STORE = emptyCustomDuelStore();
       setRemoteMiniFantasyEntries([]);
       setRemoteMiniFantasyLeaderboardEntries([]);
+      setRemoteMiniFantasyLeaderboardRows([]);
       setRemoteMiniFantasyProfiles([]);
       setRemoteMiniFantasyDailyBonuses([]);
       MINI_FANTASY_PUBLIC_DATA_STATUS = 'idle';

--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -1620,3 +1620,43 @@ export function buildMiniFantasyLeaderboard({
     rows
   };
 }
+
+export function serializeMiniFantasyLeaderboardRows({
+  leaderboard = null,
+  season = MINI_FANTASY_SEASON,
+  liveData = {},
+  generatedAtUtc = new Date().toISOString()
+} = {}) {
+  const safeSeason = normalizeWhitespace(season || MINI_FANTASY_SEASON) || MINI_FANTASY_SEASON;
+  const safeGeneratedAt = normalizeWhitespace(generatedAtUtc || new Date().toISOString()) || new Date().toISOString();
+  const liveDataFetchedAt = normalizeWhitespace(liveData?.fetchedAt || liveData?.meta?.fetchedAt || '') || null;
+  const completedMatchCount = Number(leaderboard?.completed_match_count || 0) || 0;
+  const rows = Array.isArray(leaderboard?.rows) ? leaderboard.rows : [];
+
+  return rows
+    .map((row, index) => {
+      const ownerHandle = normalizeWhitespace(row?.owner_handle || row?.ownerHandle || '');
+      if (!ownerHandle) return null;
+      return {
+        season: safeSeason,
+        owner_handle: ownerHandle,
+        user_id: normalizeWhitespace(row?.user_id || row?.userId || '') || null,
+        display_name: normalizeWhitespace(row?.display_name || row?.displayName || ownerHandle),
+        rank: Number(row?.rank || 0) || index + 1,
+        medal: normalizeWhitespace(row?.medal || '') || null,
+        total_points: roundTo(toNumber(row?.total_points, 0), 2),
+        saved_entries: Number(row?.saved_entries || 0) || 0,
+        scored_entries: Number(row?.scored_entries || 0) || 0,
+        pending_entries: Number(row?.pending_entries || 0) || 0,
+        latest_saved_at: row?.latest_saved_at || null,
+        daily_bonus_points: roundTo(toNumber(row?.daily_bonus_points, 0), 2),
+        missed_lock_points: roundTo(toNumber(row?.missed_lock_points, 0), 2),
+        new_player_baseline_points: roundTo(toNumber(row?.new_player_baseline_points, 0), 2),
+        completed_match_count: completedMatchCount,
+        matches: JSON.parse(JSON.stringify(Array.isArray(row?.matches) ? row.matches : [])),
+        live_data_fetched_at: liveDataFetchedAt,
+        generated_at: safeGeneratedAt
+      };
+    })
+    .filter(Boolean);
+}

--- a/scripts/publish-mini-fantasy-leaderboard.mjs
+++ b/scripts/publish-mini-fantasy-leaderboard.mjs
@@ -1,0 +1,187 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  MINI_FANTASY_SEASON,
+  buildMiniFantasyLeaderboard,
+  serializeMiniFantasyLeaderboardRows
+} from '../mini-fantasy/contest-engine.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_SUPABASE_URL = 'https://qvigsvrxahuopeuefizy.supabase.co';
+const PAGE_SIZE = 1000;
+
+function normalizeWhitespace(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function parseResponsePayload(text) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function errorMessageFromPayload(payload, fallback) {
+  if (!payload) return fallback;
+  if (typeof payload === 'string') return payload || fallback;
+  return payload.msg
+    || payload.message
+    || payload.error_description
+    || payload.error
+    || payload.hint
+    || fallback;
+}
+
+async function readJson(relativePath) {
+  const absolutePath = path.resolve(ROOT, relativePath);
+  const raw = await fs.readFile(absolutePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function requestJson(url, { method = 'GET', headers = {}, body = null } = {}) {
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body == null ? undefined : JSON.stringify(body)
+  });
+  const payload = parseResponsePayload(await response.text());
+  if (!response.ok) {
+    throw new Error(errorMessageFromPayload(payload, `Request failed: HTTP ${response.status}`));
+  }
+  return payload;
+}
+
+function buildRestHeaders(serviceRoleKey, extraHeaders = {}) {
+  return {
+    apikey: serviceRoleKey,
+    Authorization: `Bearer ${serviceRoleKey}`,
+    ...extraHeaders
+  };
+}
+
+async function fetchAllRows(baseUrl, serviceRoleKey, table, query = {}) {
+  const results = [];
+  for (let start = 0; ; start += PAGE_SIZE) {
+    const url = new URL(`/rest/v1/${table}`, baseUrl);
+    Object.entries(query).forEach(([key, value]) => {
+      if (value != null && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    });
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: buildRestHeaders(serviceRoleKey, {
+        Range: `${start}-${start + PAGE_SIZE - 1}`,
+        Prefer: 'count=exact'
+      })
+    });
+    const payload = parseResponsePayload(await response.text());
+    if (!response.ok) {
+      throw new Error(errorMessageFromPayload(payload, `Request failed: HTTP ${response.status}`));
+    }
+    const rows = Array.isArray(payload) ? payload : [];
+    results.push(...rows);
+    if (rows.length < PAGE_SIZE) break;
+  }
+  return results;
+}
+
+async function deleteSeasonRows(baseUrl, serviceRoleKey, season) {
+  const url = new URL('/rest/v1/mini_fantasy_leaderboard_rows', baseUrl);
+  url.searchParams.set('season', `eq.${season}`);
+  await requestJson(url.toString(), {
+    method: 'DELETE',
+    headers: buildRestHeaders(serviceRoleKey, {
+      Prefer: 'return=minimal'
+    })
+  });
+}
+
+async function insertRows(baseUrl, serviceRoleKey, rows = []) {
+  if (!rows.length) return;
+  for (let start = 0; start < rows.length; start += PAGE_SIZE) {
+    const chunk = rows.slice(start, start + PAGE_SIZE);
+    const url = new URL('/rest/v1/mini_fantasy_leaderboard_rows', baseUrl);
+    url.searchParams.set('on_conflict', 'season,owner_handle');
+    await requestJson(url.toString(), {
+      method: 'POST',
+      headers: buildRestHeaders(serviceRoleKey, {
+        'Content-Type': 'application/json',
+        Prefer: 'resolution=merge-duplicates,return=minimal'
+      }),
+      body: chunk
+    });
+  }
+}
+
+async function main() {
+  const supabaseUrl = normalizeWhitespace(process.env.SUPABASE_URL || DEFAULT_SUPABASE_URL);
+  const serviceRoleKey = normalizeWhitespace(process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+  const season = normalizeWhitespace(process.env.MINI_FANTASY_SEASON || MINI_FANTASY_SEASON) || MINI_FANTASY_SEASON;
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.log('Mini Fantasy leaderboard publish skipped: missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.');
+    return;
+  }
+
+  const [liveData, scheduleData, squads] = await Promise.all([
+    readJson('data/live.json'),
+    readJson('ipl_2026_schedule.json'),
+    readJson('ipl_2026_squads.json')
+  ]);
+  const schedule = Array.isArray(scheduleData?.matches) ? scheduleData.matches : [];
+  const publicVisibleAtUtc = new Date(Date.now() + 60 * 1000).toISOString();
+
+  const [entries, profiles, dailyBonuses] = await Promise.all([
+    fetchAllRows(supabaseUrl, serviceRoleKey, 'mini_fantasy_entries', {
+      select: 'id,user_id,owner_handle,display_name,season,match_no,home_team_code,away_team_code,fixture_label,fixture_datetime_utc,selected_player_ids,captain_player_id,price_snapshot,spent_credits,saved_at,created_at,updated_at',
+      season: `eq.${season}`,
+      fixture_datetime_utc: `lte.${publicVisibleAtUtc}`,
+      order: 'saved_at.desc.nullslast,fixture_datetime_utc.asc.nullslast,match_no.asc'
+    }),
+    fetchAllRows(supabaseUrl, serviceRoleKey, 'profiles', {
+      select: 'id,handle,display_name,email,created_at',
+      order: 'created_at.asc.nullslast'
+    }),
+    fetchAllRows(supabaseUrl, serviceRoleKey, 'mini_fantasy_daily_bonus_claims', {
+      select: 'id,user_id,owner_handle,display_name,season,bonus_date_ist,bonus_points,created_at',
+      season: `eq.${season}`,
+      order: 'bonus_date_ist.asc.nullslast,created_at.asc.nullslast'
+    }).catch((error) => {
+      console.warn('Mini Fantasy daily bonus rows skipped during publish:', error.message);
+      return [];
+    })
+  ]);
+
+  const leaderboard = buildMiniFantasyLeaderboard({
+    entries,
+    liveData,
+    schedule,
+    squads,
+    profiles,
+    dailyBonuses
+  });
+  const rows = serializeMiniFantasyLeaderboardRows({
+    leaderboard,
+    season,
+    liveData,
+    generatedAtUtc: new Date().toISOString()
+  });
+
+  await deleteSeasonRows(supabaseUrl, serviceRoleKey, season);
+  await insertRows(supabaseUrl, serviceRoleKey, rows);
+
+  console.log(
+    `Published ${rows.length} Mini Fantasy leaderboard rows for ${season} using live snapshot ${liveData?.fetchedAt || 'unknown'}.`
+  );
+}
+
+main().catch((error) => {
+  console.error('Mini Fantasy leaderboard publish failed:', error);
+  process.exitCode = 1;
+});

--- a/tests/duels-backend.wiring.test.mjs
+++ b/tests/duels-backend.wiring.test.mjs
@@ -15,6 +15,7 @@ test('backend config, adapter, and setup docs are present for real auth + duel a
   assert.match(configJs, /DUELS_BACKEND_CONFIG/);
   assert.match(configJs, /supabaseUrl/);
   assert.match(configJs, /supabaseAnonKey/);
+  assert.match(configJs, /miniFantasyLeaderboardRows/);
 
   assert.match(backendJs, /createDuelsBackend/);
   assert.match(backendJs, /signUp/);
@@ -28,6 +29,7 @@ test('backend config, adapter, and setup docs are present for real auth + duel a
   assert.match(backendJs, /saveOwnedEntry/);
   assert.match(backendJs, /listMiniFantasyEntries/);
   assert.match(backendJs, /listPublicMiniFantasyEntries/);
+  assert.match(backendJs, /listMiniFantasyLeaderboardRows/);
   assert.match(backendJs, /fixture_datetime_utc:\s*`lte\.\$\{publicVisibleAtUtc\}`/);
   assert.match(backendJs, /upsertMiniFantasyEntry/);
 
@@ -39,7 +41,9 @@ test('backend config, adapter, and setup docs are present for real auth + duel a
   assert.match(schemaSql, /create table if not exists public\.duels/i);
   assert.match(schemaSql, /create table if not exists public\.duel_entries/i);
   assert.match(schemaSql, /create table if not exists public\.mini_fantasy_entries/i);
+  assert.match(schemaSql, /create table if not exists public\.mini_fantasy_leaderboard_rows/i);
   assert.match(schemaSql, /create policy "users read their own mini fantasy entries"/i);
   assert.match(schemaSql, /create policy "locked mini fantasy entries are public readable"/i);
+  assert.match(schemaSql, /create policy "mini fantasy leaderboard rows are public readable"/i);
   assert.match(schemaSql, /enable row level security/i);
 });

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -14,6 +14,7 @@ import {
   generateMiniFantasyPriceBook,
   getMiniFantasyOpenFixtures,
   resolvePlayerHistory,
+  serializeMiniFantasyLeaderboardRows,
   scoreMiniFantasyEntry,
   validateMiniFantasyEntry
 } from '../mini-fantasy/contest-engine.js';
@@ -1173,6 +1174,71 @@ test('buildMiniFantasyLeaderboard uses profile created_at ahead of first saved-e
   assert.equal(earlyBird.missed_lock_points, 0);
   assert.equal(earlyBird.matches[0].source, 'locked_entry');
   assert.equal(earlyBird.saved_entries, 1);
+});
+
+test('serializeMiniFantasyLeaderboardRows keeps the leaderboard snapshot shape stable for database publishing', () => {
+  const rows = serializeMiniFantasyLeaderboardRows({
+    leaderboard: {
+      completed_match_count: 14,
+      rows: [
+        {
+          owner_handle: 'senthil',
+          user_id: 'user-senthil',
+          display_name: 'Senthil',
+          rank: 1,
+          medal: 'gold',
+          total_points: 123.5,
+          saved_entries: 2,
+          scored_entries: 2,
+          pending_entries: 0,
+          latest_saved_at: '2026-04-10T15:00:00Z',
+          daily_bonus_points: 5,
+          missed_lock_points: 10,
+          new_player_baseline_points: 40,
+          matches: [
+            {
+              match_no: 14,
+              total_points: 83.5,
+              source: 'locked_entry'
+            }
+          ]
+        }
+      ]
+    },
+    liveData: {
+      fetchedAt: '2026-04-19T10:00:00Z'
+    },
+    generatedAtUtc: '2026-04-19T10:05:00Z'
+  });
+
+  assert.deepEqual(rows, [
+    {
+      season: 'IPL 2026',
+      owner_handle: 'senthil',
+      user_id: 'user-senthil',
+      display_name: 'Senthil',
+      rank: 1,
+      medal: 'gold',
+      total_points: 123.5,
+      saved_entries: 2,
+      scored_entries: 2,
+      pending_entries: 0,
+      latest_saved_at: '2026-04-10T15:00:00Z',
+      daily_bonus_points: 5,
+      missed_lock_points: 10,
+      new_player_baseline_points: 40,
+      completed_match_count: 14,
+      matches: [
+        {
+          match_no: 14,
+          total_points: 83.5,
+          source: 'locked_entry'
+        }
+      ],
+      live_data_fetched_at: '2026-04-19T10:00:00Z',
+      generated_at: '2026-04-19T10:05:00Z'
+    }
+  ]);
 });
 
 test('calculateMiniFantasyMissedLockPoints lowers the cap after the third missed lock', () => {

--- a/tests/page.directory-wiring.test.mjs
+++ b/tests/page.directory-wiring.test.mjs
@@ -54,6 +54,7 @@ test('public duel directory wiring exists in the page shell', async () => {
   assert.match(html, /function withFreshLifecycle\(/);
   assert.match(html, /function syncRemoteBundlesForRoom\(/);
   assert.match(html, /function syncMiniFantasyEntries\(/);
+  assert.match(html, /function upsertRemoteMiniFantasyEntry\(/);
   assert.match(html, /function loadPlayerAvailabilityData\(/);
   assert.match(html, /function miniFantasyAvailabilityBadgeLabel\(/);
   assert.match(html, /function renderMiniFantasySection\(/);
@@ -90,6 +91,7 @@ test('public duel directory wiring exists in the page shell', async () => {
   assert.match(html, /Missed-lock safety net:/);
   assert.match(html, /Fixture-day visit bonus:/);
   assert.match(html, /New-player catch-up:/);
+  assert.match(html, /function upsertRemoteMiniFantasyEntry\([\s\S]*MINI_FANTASY_FORCE_LEADERBOARD_FALLBACK = true;/);
   assert.match(html, /Opens the day before/);
   assert.match(html, /Locks at/);
   assert.match(html, /data-directory-filter=/);


### PR DESCRIPTION
## Summary
- add a precomputed `mini_fantasy_leaderboard_rows` snapshot table and backend reader
- publish leaderboard snapshots from the live-data workflow with a service-role publisher script
- let the frontend use fresh snapshot rows when they match the current `data/live.json` fetch time, with a safe fallback to the existing client-side computation

## Safety
- does not change `mini_fantasy_entries` storage or write rules
- locked team ids, captain picks, and frozen price snapshots stay untouched
- if the new table is empty or stale, the UI falls back to the current in-browser leaderboard build

## Validation
- node suite passed: `95/95`
- publisher script no-ops safely when the service-role env vars are absent

## Follow-up after merge
- run the updated `docs/duels_backend_supabase.sql`
- add `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` to the live-data workflow secrets so the snapshot publisher can write rows
