### PR TITLE
Support targeted scorecard refetch for Match 31 repair

### DIFF
--- a/.github/workflows/update-live-data.yml
+++ b/.github/workflows/update-live-data.yml
@@ -27,6 +27,10 @@ on:
         description: Minimum scorecard innings expected
         required: false
         default: '2'
+      force_refetch_scorecard_ids:
+        description: Comma-separated CricketData match ids to refetch even when cached
+        required: false
+        default: ''
   schedule:
     - cron: '0 9,13,14,15,18,19 28-31 3 *'
     - cron: '0 9,13,14,15,18,19 * 4 *'
@@ -95,6 +99,7 @@ jobs:
           CRICKETDATA_MAX_BACKLOG_SCORECARDS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && '12' || '2' }}
           CRICKETDATA_MAX_FRESH_SCORECARD_CALLS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && '12' || '1' }}
           CRICKETDATA_ALLOW_HISTORICAL_REPLAY: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
+          CRICKETDATA_FORCE_REFETCH_SCORECARD_IDS: ${{ github.event_name == 'workflow_dispatch' && inputs.force_refetch_scorecard_ids || '' }}
         run: node scripts/update-live-data.mjs
 
       - name: Validate live data contract

--- a/.github/workflows/update-live-data.yml
+++ b/.github/workflows/update-live-data.yml
@@ -109,6 +109,7 @@ jobs:
         run: node scripts/update-mini-fantasy-prices.mjs
 
       - name: Publish Mini Fantasy leaderboard snapshot
+        if: github.ref_name == 'main'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/data/mini_fantasy_prices.json
+++ b/data/mini_fantasy_prices.json
@@ -1,7 +1,7 @@
 {
   "job_meta": {
     "season": "IPL 2026",
-    "as_of_utc": "2026-04-21T21:13:00.688Z",
+    "as_of_utc": "2026-04-22T08:03:42.012Z",
     "price_min": 4,
     "price_max": 10,
     "recent_matches_window": 3,
@@ -18,8 +18,8 @@
     "total_players_received": 254,
     "eligible_players_ranked": 254,
     "price_rises": 0,
-    "price_drops": 2,
-    "price_unchanged": 252
+    "price_drops": 0,
+    "price_unchanged": 254
   },
   "players": [
     {
@@ -157,10 +157,10 @@
       "score_basis": 28.73,
       "reliability_factor": 1,
       "adjusted_score": 28.73,
-      "percentile": 72.33,
+      "percentile": 72.73,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 72.33",
+        "Target price mapped from percentile 72.73",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -186,10 +186,10 @@
       "score_basis": 27.77,
       "reliability_factor": 1,
       "adjusted_score": 27.77,
-      "percentile": 71.54,
+      "percentile": 71.94,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 71.54",
+        "Target price mapped from percentile 71.94",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -215,10 +215,10 @@
       "score_basis": 13.5,
       "reliability_factor": 1,
       "adjusted_score": 13.5,
-      "percentile": 53.16,
+      "percentile": 54.15,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 53.16",
+        "Target price mapped from percentile 54.15",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T00:00:00"
@@ -244,7 +244,7 @@
       "score_basis": 32.77,
       "reliability_factor": 1,
       "adjusted_score": 32.77,
-      "percentile": 78.26,
+      "percentile": 77.87,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -271,7 +271,7 @@
       "score_basis": 17.5,
       "reliability_factor": 0.75,
       "adjusted_score": 13.13,
-      "percentile": 52.17,
+      "percentile": 53.36,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -326,10 +326,10 @@
       "score_basis": 30,
       "reliability_factor": 0.75,
       "adjusted_score": 22.5,
-      "percentile": 65.61,
+      "percentile": 66.4,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 65.61",
+        "Target price mapped from percentile 66.4",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -355,10 +355,10 @@
       "score_basis": 22.35,
       "reliability_factor": 1,
       "adjusted_score": 22.35,
-      "percentile": 65.22,
+      "percentile": 65.61,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 65.22",
+        "Target price mapped from percentile 65.61",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -372,7 +372,7 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
@@ -384,11 +384,9 @@
       "score_basis": 9.67,
       "reliability_factor": 0.75,
       "adjusted_score": 7.25,
-      "percentile": 44.66,
+      "percentile": 45.06,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 44.66",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-05T00:00:00"
     },
@@ -413,7 +411,7 @@
       "score_basis": 22,
       "reliability_factor": 0.5,
       "adjusted_score": 11,
-      "percentile": 50.4,
+      "percentile": 51.19,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -440,7 +438,7 @@
       "score_basis": 26.5,
       "reliability_factor": 0.5,
       "adjusted_score": 13.25,
-      "percentile": 52.57,
+      "percentile": 53.75,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -467,10 +465,10 @@
       "score_basis": 4.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.25,
-      "percentile": 41.5,
+      "percentile": 42.09,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 41.5",
+        "Target price mapped from percentile 42.09",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T00:00:00"
@@ -496,7 +494,7 @@
       "score_basis": 19.07,
       "reliability_factor": 1,
       "adjusted_score": 19.07,
-      "percentile": 61.66,
+      "percentile": 60.87,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -523,10 +521,10 @@
       "score_basis": 15.5,
       "reliability_factor": 1,
       "adjusted_score": 15.5,
-      "percentile": 55.73,
+      "percentile": 56.52,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 55.73",
+        "Target price mapped from percentile 56.52",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00"
@@ -552,10 +550,10 @@
       "score_basis": 15.5,
       "reliability_factor": 0.75,
       "adjusted_score": 11.63,
-      "percentile": 51.38,
+      "percentile": 52.17,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 51.38",
+        "Target price mapped from percentile 52.17",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -778,7 +776,7 @@
       "score_basis": 37.8,
       "reliability_factor": 1,
       "adjusted_score": 37.8,
-      "percentile": 82.61,
+      "percentile": 85.38,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -829,11 +827,11 @@
       "matches_played": 7,
       "season_total_points": 213,
       "season_avg_points": 30.43,
-      "recent_avg_points": 36.83,
-      "last_match_points": 16.5,
-      "score_basis": 34.27,
+      "recent_avg_points": 36.33,
+      "last_match_points": 15,
+      "score_basis": 33.97,
       "reliability_factor": 1,
-      "adjusted_score": 34.27,
+      "adjusted_score": 33.97,
       "percentile": 79.05,
       "calculation_notes": [
         "Used old_price for smoothing"
@@ -861,10 +859,10 @@
       "score_basis": 37.04,
       "reliability_factor": 1,
       "adjusted_score": 37.04,
-      "percentile": 81.42,
+      "percentile": 82.61,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 81.42",
+        "Target price mapped from percentile 82.61",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -885,15 +883,15 @@
       "matches_played": 7,
       "season_total_points": 135.5,
       "season_avg_points": 19.36,
-      "recent_avg_points": 12.33,
-      "last_match_points": -2,
-      "score_basis": 15.14,
+      "recent_avg_points": 11.33,
+      "last_match_points": -5,
+      "score_basis": 14.54,
       "reliability_factor": 1,
-      "adjusted_score": 15.14,
-      "percentile": 55.34,
+      "adjusted_score": 14.54,
+      "percentile": 54.94,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 55.34",
+        "Target price mapped from percentile 54.94",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -912,17 +910,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 212,
-      "season_avg_points": 30.29,
+      "season_total_points": 222.5,
+      "season_avg_points": 31.79,
       "recent_avg_points": 11,
       "last_match_points": -5,
-      "score_basis": 18.72,
+      "score_basis": 19.32,
       "reliability_factor": 1,
-      "adjusted_score": 18.72,
-      "percentile": 60.08,
+      "adjusted_score": 19.32,
+      "percentile": 61.26,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 60.08",
+        "Target price mapped from percentile 61.26",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -943,15 +941,15 @@
       "matches_played": 7,
       "season_total_points": 197,
       "season_avg_points": 28.14,
-      "recent_avg_points": 9.67,
-      "last_match_points": 9,
-      "score_basis": 17.06,
+      "recent_avg_points": 6.67,
+      "last_match_points": 0,
+      "score_basis": 15.26,
       "reliability_factor": 1,
-      "adjusted_score": 17.06,
-      "percentile": 57.71,
+      "adjusted_score": 15.26,
+      "percentile": 56.13,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 57.71",
+        "Target price mapped from percentile 56.13",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -970,13 +968,13 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 228,
-      "season_avg_points": 38,
+      "season_total_points": 223,
+      "season_avg_points": 37.17,
       "recent_avg_points": 5.33,
       "last_match_points": 8,
-      "score_basis": 18.4,
+      "score_basis": 18.07,
       "reliability_factor": 1,
-      "adjusted_score": 18.4,
+      "adjusted_score": 18.07,
       "percentile": 59.29,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -1001,15 +999,15 @@
       "matches_played": 7,
       "season_total_points": 138.5,
       "season_avg_points": 19.79,
-      "recent_avg_points": 2.83,
-      "last_match_points": 4.5,
-      "score_basis": 9.61,
+      "recent_avg_points": 1.33,
+      "last_match_points": 0,
+      "score_basis": 8.71,
       "reliability_factor": 1,
-      "adjusted_score": 9.61,
-      "percentile": 47.04,
+      "adjusted_score": 8.71,
+      "percentile": 46.25,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 47.04",
+        "Target price mapped from percentile 46.25",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -1035,7 +1033,7 @@
       "score_basis": 31,
       "reliability_factor": 0.25,
       "adjusted_score": 7.75,
-      "percentile": 45.06,
+      "percentile": 45.45,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1050,21 +1048,23 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 52,
-      "season_avg_points": 10.4,
-      "recent_avg_points": 9.83,
-      "last_match_points": 5.5,
-      "score_basis": 10.06,
+      "season_total_points": 41.5,
+      "season_avg_points": 8.3,
+      "recent_avg_points": 6.33,
+      "last_match_points": -5,
+      "score_basis": 7.12,
       "reliability_factor": 1,
-      "adjusted_score": 10.06,
-      "percentile": 47.83,
+      "adjusted_score": 7.12,
+      "percentile": 44.66,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 44.66",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
     },
@@ -1089,7 +1089,7 @@
       "score_basis": 11.1,
       "reliability_factor": 1,
       "adjusted_score": 11.1,
-      "percentile": 50.99,
+      "percentile": 51.78,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1228,7 +1228,7 @@
       "score_basis": 5,
       "reliability_factor": 0.25,
       "adjusted_score": 1.25,
-      "percentile": 38.74,
+      "percentile": 39.13,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1416,17 +1416,17 @@
       "final_price": 5,
       "price_change": 0,
       "matches_played": 3,
-      "season_total_points": 13,
-      "season_avg_points": 4.33,
-      "recent_avg_points": 4.33,
-      "last_match_points": 0,
-      "score_basis": 4.33,
+      "season_total_points": 8,
+      "season_avg_points": 2.67,
+      "recent_avg_points": 2.67,
+      "last_match_points": -5,
+      "score_basis": 2.67,
       "reliability_factor": 0.75,
-      "adjusted_score": 3.25,
-      "percentile": 42.69,
+      "adjusted_score": 2,
+      "percentile": 41.5,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 42.69",
+        "Target price mapped from percentile 41.5",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -1476,11 +1476,11 @@
       "matches_played": 7,
       "season_total_points": 348.5,
       "season_avg_points": 49.79,
-      "recent_avg_points": 66.33,
-      "last_match_points": 102,
-      "score_basis": 59.71,
+      "recent_avg_points": 61.33,
+      "last_match_points": 87,
+      "score_basis": 56.71,
       "reliability_factor": 1,
-      "adjusted_score": 59.71,
+      "adjusted_score": 56.71,
       "percentile": 96.05,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -1505,11 +1505,11 @@
       "matches_played": 7,
       "season_total_points": 359,
       "season_avg_points": 51.29,
-      "recent_avg_points": 51.67,
-      "last_match_points": 21,
-      "score_basis": 51.52,
+      "recent_avg_points": 49.67,
+      "last_match_points": 15,
+      "score_basis": 50.32,
       "reliability_factor": 1,
-      "adjusted_score": 51.52,
+      "adjusted_score": 50.32,
       "percentile": 90.91,
       "calculation_notes": [
         "Used old_price for smoothing"
@@ -1559,14 +1559,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 193.5,
-      "season_avg_points": 27.64,
-      "recent_avg_points": 27.67,
-      "last_match_points": 8,
-      "score_basis": 27.66,
+      "season_total_points": 188.5,
+      "season_avg_points": 26.93,
+      "recent_avg_points": 23.67,
+      "last_match_points": -4,
+      "score_basis": 24.97,
       "reliability_factor": 1,
-      "adjusted_score": 27.66,
-      "percentile": 70.75,
+      "adjusted_score": 24.97,
+      "percentile": 68.38,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1581,7 +1581,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 7,
+      "target_price": 8,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -1593,11 +1593,9 @@
       "score_basis": 22.13,
       "reliability_factor": 1,
       "adjusted_score": 22.13,
-      "percentile": 64.82,
+      "percentile": 65.22,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 64.82",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -1617,15 +1615,15 @@
       "matches_played": 7,
       "season_total_points": 246.5,
       "season_avg_points": 35.21,
-      "recent_avg_points": 42.83,
-      "last_match_points": 36.5,
-      "score_basis": 39.78,
+      "recent_avg_points": 37.33,
+      "last_match_points": 20,
+      "score_basis": 36.48,
       "reliability_factor": 1,
-      "adjusted_score": 39.78,
-      "percentile": 84.19,
+      "adjusted_score": 36.48,
+      "percentile": 80.63,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 84.19",
+        "Target price mapped from percentile 80.63",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -1646,15 +1644,15 @@
       "matches_played": 7,
       "season_total_points": 254,
       "season_avg_points": 36.29,
-      "recent_avg_points": 11.17,
-      "last_match_points": 13.5,
-      "score_basis": 21.22,
+      "recent_avg_points": 8.67,
+      "last_match_points": 6,
+      "score_basis": 19.72,
       "reliability_factor": 1,
-      "adjusted_score": 21.22,
-      "percentile": 64.03,
+      "adjusted_score": 19.72,
+      "percentile": 61.66,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.03",
+        "Target price mapped from percentile 61.66",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -1709,10 +1707,10 @@
       "score_basis": 10.32,
       "reliability_factor": 1,
       "adjusted_score": 10.32,
-      "percentile": 48.62,
+      "percentile": 49.41,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 48.62",
+        "Target price mapped from percentile 49.41",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -1733,12 +1731,12 @@
       "matches_played": 7,
       "season_total_points": 219,
       "season_avg_points": 31.29,
-      "recent_avg_points": 27.17,
-      "last_match_points": 32.5,
-      "score_basis": 28.82,
+      "recent_avg_points": 26.67,
+      "last_match_points": 31,
+      "score_basis": 28.52,
       "reliability_factor": 1,
-      "adjusted_score": 28.82,
-      "percentile": 72.73,
+      "adjusted_score": 28.52,
+      "percentile": 72.33,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1751,12 +1749,12 @@
       "role": "wicket_keeper",
       "is_uncapped": true,
       "pricing_eligible": true,
-      "old_price": 8,
-      "initial_price": 8,
+      "old_price": 7,
+      "initial_price": 7,
       "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
-      "price_change": -1,
+      "price_change": 0,
       "matches_played": 1,
       "season_total_points": 26,
       "season_avg_points": 26,
@@ -1765,10 +1763,10 @@
       "score_basis": 26,
       "reliability_factor": 0.25,
       "adjusted_score": 6.5,
-      "percentile": 44.07,
+      "percentile": 44.27,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 44.07",
+        "Target price mapped from percentile 44.27",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T00:00:00"
@@ -1794,7 +1792,7 @@
       "score_basis": 9.73,
       "reliability_factor": 1,
       "adjusted_score": 9.73,
-      "percentile": 47.43,
+      "percentile": 47.83,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2157,10 +2155,10 @@
       "score_basis": 25.54,
       "reliability_factor": 1,
       "adjusted_score": 25.54,
-      "percentile": 68.77,
+      "percentile": 69.17,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 68.77",
+        "Target price mapped from percentile 69.17",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2208,17 +2206,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 199,
-      "season_avg_points": 28.43,
-      "recent_avg_points": 11.67,
+      "season_total_points": 194,
+      "season_avg_points": 27.71,
+      "recent_avg_points": 10,
       "last_match_points": 3,
-      "score_basis": 18.37,
+      "score_basis": 17.08,
       "reliability_factor": 1,
-      "adjusted_score": 18.37,
-      "percentile": 58.89,
+      "adjusted_score": 17.08,
+      "percentile": 58.5,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 58.89",
+        "Target price mapped from percentile 58.5",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2264,17 +2262,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 8,
-      "season_total_points": 263.5,
-      "season_avg_points": 32.94,
-      "recent_avg_points": 50.83,
-      "last_match_points": 47.5,
-      "score_basis": 43.67,
+      "season_total_points": 256,
+      "season_avg_points": 32,
+      "recent_avg_points": 48.33,
+      "last_match_points": 40,
+      "score_basis": 41.8,
       "reliability_factor": 1,
-      "adjusted_score": 43.67,
-      "percentile": 87.35,
+      "adjusted_score": 41.8,
+      "percentile": 86.96,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 87.35",
+        "Target price mapped from percentile 86.96",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2300,10 +2298,10 @@
       "score_basis": 10.96,
       "reliability_factor": 1,
       "adjusted_score": 10.96,
-      "percentile": 49.8,
+      "percentile": 50.59,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 49.8",
+        "Target price mapped from percentile 50.59",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00"
@@ -2322,17 +2320,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 298,
-      "season_avg_points": 42.57,
-      "recent_avg_points": 54.5,
-      "last_match_points": 99.5,
-      "score_basis": 49.73,
+      "season_total_points": 278.5,
+      "season_avg_points": 39.79,
+      "recent_avg_points": 48,
+      "last_match_points": 80,
+      "score_basis": 44.72,
       "reliability_factor": 1,
-      "adjusted_score": 49.73,
-      "percentile": 90.51,
+      "adjusted_score": 44.72,
+      "percentile": 87.75,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 90.51",
+        "Target price mapped from percentile 87.75",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2358,7 +2356,7 @@
       "score_basis": 26.74,
       "reliability_factor": 1,
       "adjusted_score": 26.74,
-      "percentile": 69.57,
+      "percentile": 71.15,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2400,7 +2398,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 9,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -2412,9 +2410,11 @@
       "score_basis": 36.5,
       "reliability_factor": 1,
       "adjusted_score": 36.5,
-      "percentile": 79.84,
+      "percentile": 81.03,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 81.03",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
     },
@@ -2432,17 +2432,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 295,
-      "season_avg_points": 42.14,
-      "recent_avg_points": 46.5,
-      "last_match_points": 64.5,
-      "score_basis": 44.76,
+      "season_total_points": 275.5,
+      "season_avg_points": 39.36,
+      "recent_avg_points": 40,
+      "last_match_points": 45,
+      "score_basis": 39.74,
       "reliability_factor": 1,
-      "adjusted_score": 44.76,
-      "percentile": 88.14,
+      "adjusted_score": 39.74,
+      "percentile": 85.77,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 88.14",
+        "Target price mapped from percentile 85.77",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2456,21 +2456,23 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 216.5,
-      "season_avg_points": 30.93,
-      "recent_avg_points": 17.33,
-      "last_match_points": 9,
-      "score_basis": 22.77,
+      "season_total_points": 207.5,
+      "season_avg_points": 29.64,
+      "recent_avg_points": 14.33,
+      "last_match_points": 0,
+      "score_basis": 20.45,
       "reliability_factor": 1,
-      "adjusted_score": 22.77,
-      "percentile": 66.4,
+      "adjusted_score": 20.45,
+      "percentile": 63.24,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 63.24",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
     },
@@ -2488,17 +2490,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 185.5,
-      "season_avg_points": 30.92,
-      "recent_avg_points": 46.5,
-      "last_match_points": 99.5,
-      "score_basis": 40.27,
+      "season_total_points": 166,
+      "season_avg_points": 27.67,
+      "recent_avg_points": 40,
+      "last_match_points": 80,
+      "score_basis": 35.07,
       "reliability_factor": 1,
-      "adjusted_score": 40.27,
-      "percentile": 84.98,
+      "adjusted_score": 35.07,
+      "percentile": 80.24,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 84.98",
+        "Target price mapped from percentile 80.24",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2524,10 +2526,10 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 40.32,
+      "percentile": 40.71,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 40.32",
+        "Target price mapped from percentile 40.71",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-03-29T00:00:00"
@@ -2541,23 +2543,21 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 26,
-      "season_avg_points": 13,
-      "recent_avg_points": 13,
-      "last_match_points": 3,
-      "score_basis": 13,
+      "season_total_points": 38,
+      "season_avg_points": 19,
+      "recent_avg_points": 19,
+      "last_match_points": 15,
+      "score_basis": 19,
       "reliability_factor": 0.5,
-      "adjusted_score": 6.5,
-      "percentile": 44.07,
+      "adjusted_score": 9.5,
+      "percentile": 47.43,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 44.07",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
     },
@@ -2827,17 +2827,17 @@
       "final_price": 5,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 9,
-      "season_avg_points": 4.5,
-      "recent_avg_points": 4.5,
-      "last_match_points": 0,
-      "score_basis": 4.5,
+      "season_total_points": 4,
+      "season_avg_points": 2,
+      "recent_avg_points": 2,
+      "last_match_points": -5,
+      "score_basis": 2,
       "reliability_factor": 0.5,
-      "adjusted_score": 2.25,
-      "percentile": 41.5,
+      "adjusted_score": 1,
+      "percentile": 38.74,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 41.5",
+        "Target price mapped from percentile 38.74",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-09T14:00:00"
@@ -2863,7 +2863,7 @@
       "score_basis": 37.43,
       "reliability_factor": 1,
       "adjusted_score": 37.43,
-      "percentile": 82.02,
+      "percentile": 83.99,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2882,15 +2882,15 @@
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
-      "matches_played": 8,
-      "season_total_points": 333.5,
-      "season_avg_points": 41.69,
-      "recent_avg_points": 42.33,
-      "last_match_points": 49.5,
-      "score_basis": 42.07,
+      "matches_played": 7,
+      "season_total_points": 323,
+      "season_avg_points": 46.14,
+      "recent_avg_points": 44.67,
+      "last_match_points": 45,
+      "score_basis": 45.26,
       "reliability_factor": 1,
-      "adjusted_score": 42.07,
-      "percentile": 86.56,
+      "adjusted_score": 45.26,
+      "percentile": 88.54,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2910,17 +2910,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 81,
-      "season_avg_points": 16.2,
-      "recent_avg_points": 5,
-      "last_match_points": 0,
-      "score_basis": 9.48,
+      "season_total_points": 76,
+      "season_avg_points": 15.2,
+      "recent_avg_points": 3.33,
+      "last_match_points": -5,
+      "score_basis": 8.08,
       "reliability_factor": 1,
-      "adjusted_score": 9.48,
-      "percentile": 46.64,
+      "adjusted_score": 8.08,
+      "percentile": 45.85,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 46.64",
+        "Target price mapped from percentile 45.85",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00"
@@ -2938,18 +2938,18 @@
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 7,
-      "season_total_points": 162.5,
-      "season_avg_points": 23.21,
-      "recent_avg_points": 17.17,
-      "last_match_points": -0.5,
-      "score_basis": 19.59,
+      "matches_played": 6,
+      "season_total_points": 159.5,
+      "season_avg_points": 26.58,
+      "recent_avg_points": 17,
+      "last_match_points": -5,
+      "score_basis": 20.83,
       "reliability_factor": 1,
-      "adjusted_score": 19.59,
-      "percentile": 62.06,
+      "adjusted_score": 20.83,
+      "percentile": 64.03,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 62.06",
+        "Target price mapped from percentile 64.03",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3002,10 +3002,10 @@
       "score_basis": 36.67,
       "reliability_factor": 1,
       "adjusted_score": 36.67,
-      "percentile": 80.24,
+      "percentile": 81.42,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 80.24",
+        "Target price mapped from percentile 81.42",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3023,14 +3023,14 @@
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 4,
-      "season_total_points": 91,
-      "season_avg_points": 22.75,
-      "recent_avg_points": 19.83,
-      "last_match_points": 19.5,
-      "score_basis": 21,
-      "reliability_factor": 1,
-      "adjusted_score": 21,
+      "matches_played": 3,
+      "season_total_points": 82,
+      "season_avg_points": 27.33,
+      "recent_avg_points": 27.33,
+      "last_match_points": 15,
+      "score_basis": 27.33,
+      "reliability_factor": 0.75,
+      "adjusted_score": 20.5,
       "percentile": 63.64,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -3060,7 +3060,7 @@
       "score_basis": 32.4,
       "reliability_factor": 1,
       "adjusted_score": 32.4,
-      "percentile": 77.47,
+      "percentile": 77.08,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3087,7 +3087,7 @@
       "score_basis": 32.87,
       "reliability_factor": 1,
       "adjusted_score": 32.87,
-      "percentile": 78.66,
+      "percentile": 78.26,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3142,7 +3142,7 @@
       "score_basis": 20.32,
       "reliability_factor": 1,
       "adjusted_score": 20.32,
-      "percentile": 63.24,
+      "percentile": 62.85,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3169,7 +3169,7 @@
       "score_basis": 12.33,
       "reliability_factor": 0.75,
       "adjusted_score": 9.25,
-      "percentile": 46.25,
+      "percentile": 47.04,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3196,10 +3196,10 @@
       "score_basis": 4.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.25,
-      "percentile": 41.5,
+      "percentile": 42.09,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 41.5",
+        "Target price mapped from percentile 42.09",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3220,15 +3220,15 @@
       "matches_played": 4,
       "season_total_points": 124.5,
       "season_avg_points": 31.13,
-      "recent_avg_points": 32,
-      "last_match_points": 46,
-      "score_basis": 31.65,
+      "recent_avg_points": 31,
+      "last_match_points": 43,
+      "score_basis": 31.05,
       "reliability_factor": 1,
-      "adjusted_score": 31.65,
-      "percentile": 76.09,
+      "adjusted_score": 31.05,
+      "percentile": 75.89,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 76.09",
+        "Target price mapped from percentile 75.89",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3242,21 +3242,23 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 8,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
-      "matches_played": 8,
-      "season_total_points": 247,
-      "season_avg_points": 30.88,
-      "recent_avg_points": 10.67,
+      "matches_played": 7,
+      "season_total_points": 236,
+      "season_avg_points": 33.71,
+      "recent_avg_points": 17.33,
       "last_match_points": 23,
-      "score_basis": 18.75,
+      "score_basis": 23.88,
       "reliability_factor": 1,
-      "adjusted_score": 18.75,
-      "percentile": 60.47,
+      "adjusted_score": 23.88,
+      "percentile": 67.19,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 67.19",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
     },
@@ -3281,7 +3283,7 @@
       "score_basis": 13,
       "reliability_factor": 1,
       "adjusted_score": 13,
-      "percentile": 51.78,
+      "percentile": 52.96,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3560,10 +3562,10 @@
       "score_basis": 2.75,
       "reliability_factor": 0.5,
       "adjusted_score": 1.38,
-      "percentile": 39.13,
+      "percentile": 39.53,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 39.13",
+        "Target price mapped from percentile 39.53",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-01T00:00:00"
@@ -3577,21 +3579,23 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 159,
-      "season_avg_points": 79.5,
-      "recent_avg_points": 79.5,
-      "last_match_points": 138,
-      "score_basis": 79.5,
+      "season_total_points": 138,
+      "season_avg_points": 69,
+      "recent_avg_points": 69,
+      "last_match_points": 117,
+      "score_basis": 69,
       "reliability_factor": 0.5,
-      "adjusted_score": 39.75,
-      "percentile": 83.79,
+      "adjusted_score": 34.5,
+      "percentile": 79.45,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 79.45",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -3616,7 +3620,7 @@
       "score_basis": 51.53,
       "reliability_factor": 1,
       "adjusted_score": 51.53,
-      "percentile": 91.3,
+      "percentile": 91.7,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3701,10 +3705,10 @@
       "score_basis": 26.96,
       "reliability_factor": 1,
       "adjusted_score": 26.96,
-      "percentile": 69.96,
+      "percentile": 71.54,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 69.96",
+        "Target price mapped from percentile 71.54",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00"
@@ -3725,15 +3729,15 @@
       "matches_played": 5,
       "season_total_points": 159,
       "season_avg_points": 31.8,
-      "recent_avg_points": 45.67,
-      "last_match_points": 60,
-      "score_basis": 40.12,
+      "recent_avg_points": 40.67,
+      "last_match_points": 45,
+      "score_basis": 37.12,
       "reliability_factor": 1,
-      "adjusted_score": 40.12,
-      "percentile": 84.58,
+      "adjusted_score": 37.12,
+      "percentile": 83,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 84.58",
+        "Target price mapped from percentile 83",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3759,10 +3763,10 @@
       "score_basis": 17.5,
       "reliability_factor": 0.5,
       "adjusted_score": 8.75,
-      "percentile": 45.85,
+      "percentile": 46.64,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 45.85",
+        "Target price mapped from percentile 46.64",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T00:00:00"
@@ -3783,15 +3787,15 @@
       "matches_played": 6,
       "season_total_points": 207,
       "season_avg_points": 34.5,
-      "recent_avg_points": 40.67,
-      "last_match_points": 33,
-      "score_basis": 38.2,
+      "recent_avg_points": 39.67,
+      "last_match_points": 30,
+      "score_basis": 37.6,
       "reliability_factor": 1,
-      "adjusted_score": 38.2,
-      "percentile": 83,
+      "adjusted_score": 37.6,
+      "percentile": 84.98,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 83",
+        "Target price mapped from percentile 84.98",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3812,15 +3816,15 @@
       "matches_played": 4,
       "season_total_points": 149,
       "season_avg_points": 37.25,
-      "recent_avg_points": 41.17,
-      "last_match_points": 58.5,
-      "score_basis": 39.6,
+      "recent_avg_points": 37.67,
+      "last_match_points": 48,
+      "score_basis": 37.5,
       "reliability_factor": 1,
-      "adjusted_score": 39.6,
-      "percentile": 83.4,
+      "adjusted_score": 37.5,
+      "percentile": 84.58,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 83.4",
+        "Target price mapped from percentile 84.58",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3846,10 +3850,10 @@
       "score_basis": 45.6,
       "reliability_factor": 1,
       "adjusted_score": 45.6,
-      "percentile": 88.54,
+      "percentile": 88.93,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 88.54",
+        "Target price mapped from percentile 88.93",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3889,12 +3893,12 @@
       "role": "all_rounder",
       "is_uncapped": false,
       "pricing_eligible": true,
-      "old_price": 9,
-      "initial_price": 9,
+      "old_price": 8,
+      "initial_price": 8,
       "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
-      "price_change": -1,
+      "price_change": 0,
       "matches_played": 6,
       "season_total_points": 145.5,
       "season_avg_points": 24.25,
@@ -3903,10 +3907,10 @@
       "score_basis": 20.3,
       "reliability_factor": 1,
       "adjusted_score": 20.3,
-      "percentile": 62.85,
+      "percentile": 62.45,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 62.85",
+        "Target price mapped from percentile 62.45",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00"
@@ -3932,7 +3936,7 @@
       "score_basis": 25.47,
       "reliability_factor": 1,
       "adjusted_score": 25.47,
-      "percentile": 68.38,
+      "percentile": 68.77,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3947,21 +3951,23 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 153,
-      "season_avg_points": 25.5,
-      "recent_avg_points": 20.67,
+      "season_total_points": 148,
+      "season_avg_points": 24.67,
+      "recent_avg_points": 19,
       "last_match_points": 19,
-      "score_basis": 22.6,
+      "score_basis": 21.27,
       "reliability_factor": 1,
-      "adjusted_score": 22.6,
-      "percentile": 66.01,
+      "adjusted_score": 21.27,
+      "percentile": 64.43,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 64.43",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -3986,7 +3992,7 @@
       "score_basis": 10.35,
       "reliability_factor": 1,
       "adjusted_score": 10.35,
-      "percentile": 49.01,
+      "percentile": 49.8,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4013,10 +4019,10 @@
       "score_basis": 1.65,
       "reliability_factor": 1,
       "adjusted_score": 1.65,
-      "percentile": 39.53,
+      "percentile": 39.92,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 39.53",
+        "Target price mapped from percentile 39.92",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T14:00:00"
@@ -4090,17 +4096,17 @@
       "final_price": 6,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 104.5,
-      "season_avg_points": 14.93,
-      "recent_avg_points": 14.83,
-      "last_match_points": 44.5,
-      "score_basis": 14.87,
+      "season_total_points": 99.5,
+      "season_avg_points": 14.21,
+      "recent_avg_points": 7.67,
+      "last_match_points": 28,
+      "score_basis": 10.29,
       "reliability_factor": 1,
-      "adjusted_score": 14.87,
-      "percentile": 54.94,
+      "adjusted_score": 10.29,
+      "percentile": 49.01,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.94",
+        "Target price mapped from percentile 49.01",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -4114,23 +4120,21 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 7,
+      "target_price": 6,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 34,
-      "season_avg_points": 17,
-      "recent_avg_points": 17,
-      "last_match_points": 25,
-      "score_basis": 17,
+      "season_total_points": 25,
+      "season_avg_points": 12.5,
+      "recent_avg_points": 12.5,
+      "last_match_points": 16,
+      "score_basis": 12.5,
       "reliability_factor": 0.5,
-      "adjusted_score": 8.5,
-      "percentile": 45.45,
+      "adjusted_score": 6.25,
+      "percentile": 43.48,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 45.45",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -4183,7 +4187,7 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 40.32,
+      "percentile": 40.71,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4238,7 +4242,7 @@
       "score_basis": 6.3,
       "reliability_factor": 1,
       "adjusted_score": 6.3,
-      "percentile": 43.48,
+      "percentile": 43.87,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4429,15 +4433,15 @@
       "matches_played": 7,
       "season_total_points": 220.5,
       "season_avg_points": 31.5,
-      "recent_avg_points": 50,
-      "last_match_points": 27,
-      "score_basis": 42.6,
+      "recent_avg_points": 46,
+      "last_match_points": 15,
+      "score_basis": 40.2,
       "reliability_factor": 1,
-      "adjusted_score": 42.6,
-      "percentile": 86.96,
+      "adjusted_score": 40.2,
+      "percentile": 86.17,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 86.96",
+        "Target price mapped from percentile 86.17",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4458,12 +4462,12 @@
       "matches_played": 6,
       "season_total_points": 185,
       "season_avg_points": 30.83,
-      "recent_avg_points": 26.67,
-      "last_match_points": 50,
-      "score_basis": 28.33,
+      "recent_avg_points": 23.67,
+      "last_match_points": 41,
+      "score_basis": 26.53,
       "reliability_factor": 1,
-      "adjusted_score": 28.33,
-      "percentile": 71.94,
+      "adjusted_score": 26.53,
+      "percentile": 70.75,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4490,10 +4494,10 @@
       "score_basis": 18,
       "reliability_factor": 1,
       "adjusted_score": 18,
-      "percentile": 58.5,
+      "percentile": 58.89,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 58.5",
+        "Target price mapped from percentile 58.89",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4539,17 +4543,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 165,
-      "season_avg_points": 27.5,
-      "recent_avg_points": 5.67,
+      "season_total_points": 173.5,
+      "season_avg_points": 28.92,
+      "recent_avg_points": 4,
       "last_match_points": 22,
-      "score_basis": 14.4,
+      "score_basis": 13.97,
       "reliability_factor": 1,
-      "adjusted_score": 14.4,
-      "percentile": 54.15,
+      "adjusted_score": 13.97,
+      "percentile": 54.55,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.15",
+        "Target price mapped from percentile 54.55",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4570,12 +4574,12 @@
       "matches_played": 7,
       "season_total_points": 189.5,
       "season_avg_points": 27.07,
-      "recent_avg_points": 22.33,
-      "last_match_points": 20,
-      "score_basis": 24.23,
+      "recent_avg_points": 19.33,
+      "last_match_points": 11,
+      "score_basis": 22.43,
       "reliability_factor": 1,
-      "adjusted_score": 24.23,
-      "percentile": 67.59,
+      "adjusted_score": 22.43,
+      "percentile": 66.01,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4597,15 +4601,15 @@
       "matches_played": 6,
       "season_total_points": 126,
       "season_avg_points": 21,
-      "recent_avg_points": 8.5,
-      "last_match_points": 27.5,
-      "score_basis": 13.5,
+      "recent_avg_points": 6,
+      "last_match_points": 20,
+      "score_basis": 12,
       "reliability_factor": 1,
-      "adjusted_score": 13.5,
-      "percentile": 53.16,
+      "adjusted_score": 12,
+      "percentile": 52.57,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 53.16",
+        "Target price mapped from percentile 52.57",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4631,7 +4635,7 @@
       "score_basis": 18.76,
       "reliability_factor": 1,
       "adjusted_score": 18.76,
-      "percentile": 60.87,
+      "percentile": 60.08,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5134,7 +5138,7 @@
       "score_basis": 61,
       "reliability_factor": 0.75,
       "adjusted_score": 45.75,
-      "percentile": 88.93,
+      "percentile": 89.33,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5190,7 +5194,7 @@
       "score_basis": 37.43,
       "reliability_factor": 1,
       "adjusted_score": 37.43,
-      "percentile": 82.02,
+      "percentile": 83.99,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5217,10 +5221,10 @@
       "score_basis": 29.5,
       "reliability_factor": 0.75,
       "adjusted_score": 22.13,
-      "percentile": 64.43,
+      "percentile": 64.82,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.43",
+        "Target price mapped from percentile 64.82",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-10T14:00:00"
@@ -5246,10 +5250,10 @@
       "score_basis": 36.83,
       "reliability_factor": 1,
       "adjusted_score": 36.83,
-      "percentile": 80.63,
+      "percentile": 81.82,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 80.63",
+        "Target price mapped from percentile 81.82",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5275,10 +5279,10 @@
       "score_basis": 47.25,
       "reliability_factor": 1,
       "adjusted_score": 47.25,
-      "percentile": 89.33,
+      "percentile": 89.72,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 89.33",
+        "Target price mapped from percentile 89.72",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5304,10 +5308,10 @@
       "score_basis": 14.6,
       "reliability_factor": 1,
       "adjusted_score": 14.6,
-      "percentile": 54.55,
+      "percentile": 55.34,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.55",
+        "Target price mapped from percentile 55.34",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5326,17 +5330,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 129.5,
-      "season_avg_points": 25.9,
-      "recent_avg_points": 11.67,
-      "last_match_points": 0,
-      "score_basis": 17.36,
+      "season_total_points": 124.5,
+      "season_avg_points": 24.9,
+      "recent_avg_points": 10,
+      "last_match_points": -5,
+      "score_basis": 15.96,
       "reliability_factor": 1,
-      "adjusted_score": 17.36,
-      "percentile": 58.1,
+      "adjusted_score": 15.96,
+      "percentile": 57.71,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 58.1",
+        "Target price mapped from percentile 57.71",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5362,7 +5366,7 @@
       "score_basis": 18.93,
       "reliability_factor": 1,
       "adjusted_score": 18.93,
-      "percentile": 61.26,
+      "percentile": 60.47,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5389,10 +5393,10 @@
       "score_basis": 25.65,
       "reliability_factor": 1,
       "adjusted_score": 25.65,
-      "percentile": 69.17,
+      "percentile": 69.57,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 69.17",
+        "Target price mapped from percentile 69.57",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5418,7 +5422,7 @@
       "score_basis": 41,
       "reliability_factor": 0.25,
       "adjusted_score": 10.25,
-      "percentile": 48.22,
+      "percentile": 48.62,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5445,7 +5449,7 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 40.32,
+      "percentile": 40.71,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5717,17 +5721,17 @@
       "final_price": 10,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 284,
-      "season_avg_points": 47.33,
-      "recent_avg_points": 43,
-      "last_match_points": 13,
-      "score_basis": 44.73,
+      "season_total_points": 296,
+      "season_avg_points": 49.33,
+      "recent_avg_points": 47,
+      "last_match_points": 25,
+      "score_basis": 47.93,
       "reliability_factor": 1,
-      "adjusted_score": 44.73,
-      "percentile": 87.75,
+      "adjusted_score": 47.93,
+      "percentile": 90.12,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 87.75",
+        "Target price mapped from percentile 90.12",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5746,14 +5750,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 298.5,
-      "season_avg_points": 42.64,
-      "recent_avg_points": 39.5,
-      "last_match_points": 41.5,
-      "score_basis": 40.76,
+      "season_total_points": 285,
+      "season_avg_points": 40.71,
+      "recent_avg_points": 35,
+      "last_match_points": 28,
+      "score_basis": 37.28,
       "reliability_factor": 1,
-      "adjusted_score": 40.76,
-      "percentile": 85.38,
+      "adjusted_score": 37.28,
+      "percentile": 83.4,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5773,17 +5777,17 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 291,
-      "season_avg_points": 41.57,
-      "recent_avg_points": 18.5,
-      "last_match_points": 17.5,
-      "score_basis": 27.73,
+      "season_total_points": 283.5,
+      "season_avg_points": 40.5,
+      "recent_avg_points": 16,
+      "last_match_points": 10,
+      "score_basis": 25.8,
       "reliability_factor": 1,
-      "adjusted_score": 27.73,
-      "percentile": 71.15,
+      "adjusted_score": 25.8,
+      "percentile": 70.16,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 71.15",
+        "Target price mapped from percentile 70.16",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5802,14 +5806,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 251,
-      "season_avg_points": 41.83,
-      "recent_avg_points": 53.33,
-      "last_match_points": 72,
-      "score_basis": 48.73,
+      "season_total_points": 236,
+      "season_avg_points": 39.33,
+      "recent_avg_points": 48.33,
+      "last_match_points": 57,
+      "score_basis": 44.73,
       "reliability_factor": 1,
-      "adjusted_score": 48.73,
-      "percentile": 89.72,
+      "adjusted_score": 44.73,
+      "percentile": 88.14,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5864,10 +5868,10 @@
       "score_basis": 32.47,
       "reliability_factor": 1,
       "adjusted_score": 32.47,
-      "percentile": 77.87,
+      "percentile": 77.47,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 77.87",
+        "Target price mapped from percentile 77.47",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5886,14 +5890,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 4,
-      "season_total_points": 110,
-      "season_avg_points": 27.5,
-      "recent_avg_points": 27.67,
-      "last_match_points": 7,
-      "score_basis": 27.6,
+      "season_total_points": 104,
+      "season_avg_points": 26,
+      "recent_avg_points": 25.67,
+      "last_match_points": 1,
+      "score_basis": 25.8,
       "reliability_factor": 1,
-      "adjusted_score": 27.6,
-      "percentile": 70.36,
+      "adjusted_score": 25.8,
+      "percentile": 70.16,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5920,10 +5924,10 @@
       "score_basis": 37,
       "reliability_factor": 1,
       "adjusted_score": 37,
-      "percentile": 81.03,
+      "percentile": 82.21,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 81.03",
+        "Target price mapped from percentile 82.21",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5942,17 +5946,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 201,
-      "season_avg_points": 28.71,
-      "recent_avg_points": 8.67,
-      "last_match_points": 26,
-      "score_basis": 16.69,
+      "season_total_points": 195,
+      "season_avg_points": 27.86,
+      "recent_avg_points": 6.67,
+      "last_match_points": 20,
+      "score_basis": 15.15,
       "reliability_factor": 1,
-      "adjusted_score": 16.69,
-      "percentile": 57.31,
+      "adjusted_score": 15.15,
+      "percentile": 55.73,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 57.31",
+        "Target price mapped from percentile 55.73",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5999,17 +6003,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 129,
-      "season_avg_points": 18.43,
-      "recent_avg_points": 14.5,
-      "last_match_points": 8.5,
-      "score_basis": 16.07,
+      "season_total_points": 127.5,
+      "season_avg_points": 18.21,
+      "recent_avg_points": 14,
+      "last_match_points": 7,
+      "score_basis": 15.68,
       "reliability_factor": 1,
-      "adjusted_score": 16.07,
-      "percentile": 56.52,
+      "adjusted_score": 15.68,
+      "percentile": 56.92,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.52",
+        "Target price mapped from percentile 56.92",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -6035,10 +6039,10 @@
       "score_basis": 19.9,
       "reliability_factor": 1,
       "adjusted_score": 19.9,
-      "percentile": 62.45,
+      "percentile": 62.06,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 62.45",
+        "Target price mapped from percentile 62.06",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00"
@@ -6064,10 +6068,10 @@
       "score_basis": 15.9,
       "reliability_factor": 1,
       "adjusted_score": 15.9,
-      "percentile": 56.13,
+      "percentile": 57.31,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.13",
+        "Target price mapped from percentile 57.31",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -6093,7 +6097,7 @@
       "score_basis": 31.65,
       "reliability_factor": 1,
       "adjusted_score": 31.65,
-      "percentile": 76.09,
+      "percentile": 76.28,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6113,14 +6117,14 @@
       "final_price": 7,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 55,
-      "season_avg_points": 27.5,
-      "recent_avg_points": 27.5,
-      "last_match_points": 40,
-      "score_basis": 27.5,
+      "season_total_points": 40,
+      "season_avg_points": 20,
+      "recent_avg_points": 20,
+      "last_match_points": 25,
+      "score_basis": 20,
       "reliability_factor": 0.5,
-      "adjusted_score": 13.75,
-      "percentile": 53.75,
+      "adjusted_score": 10,
+      "percentile": 48.22,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6446,17 +6450,17 @@
       "final_price": 10,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 344,
-      "season_avg_points": 57.33,
+      "season_total_points": 351.5,
+      "season_avg_points": 58.58,
       "recent_avg_points": 44,
       "last_match_points": 64,
-      "score_basis": 49.33,
+      "score_basis": 49.83,
       "reliability_factor": 1,
-      "adjusted_score": 49.33,
-      "percentile": 90.12,
+      "adjusted_score": 49.83,
+      "percentile": 90.51,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 90.12",
+        "Target price mapped from percentile 90.51",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6504,13 +6508,13 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 156,
-      "season_avg_points": 31.2,
+      "season_total_points": 163.5,
+      "season_avg_points": 32.7,
       "recent_avg_points": 19.67,
       "last_match_points": -5,
-      "score_basis": 24.28,
+      "score_basis": 24.88,
       "reliability_factor": 1,
-      "adjusted_score": 24.28,
+      "adjusted_score": 24.88,
       "percentile": 67.98,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -6533,14 +6537,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 346,
-      "season_avg_points": 49.43,
-      "recent_avg_points": 53.67,
+      "season_total_points": 341,
+      "season_avg_points": 48.71,
+      "recent_avg_points": 52,
       "last_match_points": 32,
-      "score_basis": 51.97,
+      "score_basis": 50.68,
       "reliability_factor": 1,
-      "adjusted_score": 51.97,
-      "percentile": 91.7,
+      "adjusted_score": 50.68,
+      "percentile": 91.3,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6596,7 +6600,7 @@
       "score_basis": 55.5,
       "reliability_factor": 0.75,
       "adjusted_score": 41.63,
-      "percentile": 86.17,
+      "percentile": 86.56,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6616,14 +6620,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 3,
-      "season_total_points": 165.5,
-      "season_avg_points": 55.17,
-      "recent_avg_points": 55.17,
+      "season_total_points": 177.5,
+      "season_avg_points": 59.17,
+      "recent_avg_points": 59.17,
       "last_match_points": 20,
-      "score_basis": 55.17,
+      "score_basis": 59.17,
       "reliability_factor": 0.75,
-      "adjusted_score": 41.38,
-      "percentile": 85.77,
+      "adjusted_score": 44.38,
+      "percentile": 87.35,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6679,10 +6683,10 @@
       "score_basis": 16.4,
       "reliability_factor": 1,
       "adjusted_score": 16.4,
-      "percentile": 56.92,
+      "percentile": 58.1,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.92",
+        "Target price mapped from percentile 58.1",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6708,10 +6712,10 @@
       "score_basis": 21.75,
       "reliability_factor": 0.5,
       "adjusted_score": 10.88,
-      "percentile": 49.41,
+      "percentile": 50.2,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 49.41",
+        "Target price mapped from percentile 50.2",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T00:00:00"
@@ -6730,14 +6734,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 216,
-      "season_avg_points": 36,
+      "season_total_points": 231,
+      "season_avg_points": 38.5,
       "recent_avg_points": 29.67,
       "last_match_points": 74,
-      "score_basis": 32.2,
+      "score_basis": 33.2,
       "reliability_factor": 1,
-      "adjusted_score": 32.2,
-      "percentile": 77.08,
+      "adjusted_score": 33.2,
+      "percentile": 78.66,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6764,10 +6768,10 @@
       "score_basis": 22,
       "reliability_factor": 0.5,
       "adjusted_score": 11,
-      "percentile": 50.4,
+      "percentile": 51.19,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 50.4",
+        "Target price mapped from percentile 51.19",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6786,14 +6790,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 186.5,
-      "season_avg_points": 31.08,
+      "season_total_points": 189.5,
+      "season_avg_points": 31.58,
       "recent_avg_points": 37,
       "last_match_points": 39,
-      "score_basis": 34.63,
+      "score_basis": 34.83,
       "reliability_factor": 1,
-      "adjusted_score": 34.63,
-      "percentile": 79.45,
+      "adjusted_score": 34.83,
+      "percentile": 79.84,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6849,10 +6853,10 @@
       "score_basis": 24,
       "reliability_factor": 1,
       "adjusted_score": 24,
-      "percentile": 67.19,
+      "percentile": 67.59,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 67.19",
+        "Target price mapped from percentile 67.59",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6934,10 +6938,9 @@
       "score_basis": 12,
       "reliability_factor": 0.25,
       "adjusted_score": 3,
-      "percentile": 42.29,
+      "percentile": 42.69,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Recovered real match history from a previously blank price; used the corrected target price immediately"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-03-28T00:00:00"
     },
@@ -7166,5 +7169,5 @@
       "last_match_played_at_utc": null
     }
   ],
-  "generated_at_utc": "2026-04-21T21:13:00.688Z"
+  "generated_at_utc": "2026-04-22T08:03:42.012Z"
 }

--- a/data/mini_fantasy_prices.json
+++ b/data/mini_fantasy_prices.json
@@ -1,7 +1,7 @@
 {
   "job_meta": {
     "season": "IPL 2026",
-    "as_of_utc": "2026-04-22T08:03:42.012Z",
+    "as_of_utc": "2026-04-21T21:13:00.688Z",
     "price_min": 4,
     "price_max": 10,
     "recent_matches_window": 3,
@@ -18,8 +18,8 @@
     "total_players_received": 254,
     "eligible_players_ranked": 254,
     "price_rises": 0,
-    "price_drops": 0,
-    "price_unchanged": 254
+    "price_drops": 2,
+    "price_unchanged": 252
   },
   "players": [
     {
@@ -157,10 +157,10 @@
       "score_basis": 28.73,
       "reliability_factor": 1,
       "adjusted_score": 28.73,
-      "percentile": 72.73,
+      "percentile": 72.33,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 72.73",
+        "Target price mapped from percentile 72.33",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -186,10 +186,10 @@
       "score_basis": 27.77,
       "reliability_factor": 1,
       "adjusted_score": 27.77,
-      "percentile": 71.94,
+      "percentile": 71.54,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 71.94",
+        "Target price mapped from percentile 71.54",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -215,10 +215,10 @@
       "score_basis": 13.5,
       "reliability_factor": 1,
       "adjusted_score": 13.5,
-      "percentile": 54.15,
+      "percentile": 53.16,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.15",
+        "Target price mapped from percentile 53.16",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T00:00:00"
@@ -244,7 +244,7 @@
       "score_basis": 32.77,
       "reliability_factor": 1,
       "adjusted_score": 32.77,
-      "percentile": 77.87,
+      "percentile": 78.26,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -271,7 +271,7 @@
       "score_basis": 17.5,
       "reliability_factor": 0.75,
       "adjusted_score": 13.13,
-      "percentile": 53.36,
+      "percentile": 52.17,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -326,10 +326,10 @@
       "score_basis": 30,
       "reliability_factor": 0.75,
       "adjusted_score": 22.5,
-      "percentile": 66.4,
+      "percentile": 65.61,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 66.4",
+        "Target price mapped from percentile 65.61",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -355,10 +355,10 @@
       "score_basis": 22.35,
       "reliability_factor": 1,
       "adjusted_score": 22.35,
-      "percentile": 65.61,
+      "percentile": 65.22,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 65.61",
+        "Target price mapped from percentile 65.22",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -372,7 +372,7 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
@@ -384,9 +384,11 @@
       "score_basis": 9.67,
       "reliability_factor": 0.75,
       "adjusted_score": 7.25,
-      "percentile": 45.06,
+      "percentile": 44.66,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 44.66",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-05T00:00:00"
     },
@@ -411,7 +413,7 @@
       "score_basis": 22,
       "reliability_factor": 0.5,
       "adjusted_score": 11,
-      "percentile": 51.19,
+      "percentile": 50.4,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -438,7 +440,7 @@
       "score_basis": 26.5,
       "reliability_factor": 0.5,
       "adjusted_score": 13.25,
-      "percentile": 53.75,
+      "percentile": 52.57,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -465,10 +467,10 @@
       "score_basis": 4.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.25,
-      "percentile": 42.09,
+      "percentile": 41.5,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 42.09",
+        "Target price mapped from percentile 41.5",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-03T00:00:00"
@@ -494,7 +496,7 @@
       "score_basis": 19.07,
       "reliability_factor": 1,
       "adjusted_score": 19.07,
-      "percentile": 60.87,
+      "percentile": 61.66,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -521,10 +523,10 @@
       "score_basis": 15.5,
       "reliability_factor": 1,
       "adjusted_score": 15.5,
-      "percentile": 56.52,
+      "percentile": 55.73,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.52",
+        "Target price mapped from percentile 55.73",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00"
@@ -550,10 +552,10 @@
       "score_basis": 15.5,
       "reliability_factor": 0.75,
       "adjusted_score": 11.63,
-      "percentile": 52.17,
+      "percentile": 51.38,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 52.17",
+        "Target price mapped from percentile 51.38",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -776,7 +778,7 @@
       "score_basis": 37.8,
       "reliability_factor": 1,
       "adjusted_score": 37.8,
-      "percentile": 85.38,
+      "percentile": 82.61,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -827,11 +829,11 @@
       "matches_played": 7,
       "season_total_points": 213,
       "season_avg_points": 30.43,
-      "recent_avg_points": 36.33,
-      "last_match_points": 15,
-      "score_basis": 33.97,
+      "recent_avg_points": 36.83,
+      "last_match_points": 16.5,
+      "score_basis": 34.27,
       "reliability_factor": 1,
-      "adjusted_score": 33.97,
+      "adjusted_score": 34.27,
       "percentile": 79.05,
       "calculation_notes": [
         "Used old_price for smoothing"
@@ -859,10 +861,10 @@
       "score_basis": 37.04,
       "reliability_factor": 1,
       "adjusted_score": 37.04,
-      "percentile": 82.61,
+      "percentile": 81.42,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 82.61",
+        "Target price mapped from percentile 81.42",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -883,15 +885,15 @@
       "matches_played": 7,
       "season_total_points": 135.5,
       "season_avg_points": 19.36,
-      "recent_avg_points": 11.33,
-      "last_match_points": -5,
-      "score_basis": 14.54,
+      "recent_avg_points": 12.33,
+      "last_match_points": -2,
+      "score_basis": 15.14,
       "reliability_factor": 1,
-      "adjusted_score": 14.54,
-      "percentile": 54.94,
+      "adjusted_score": 15.14,
+      "percentile": 55.34,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.94",
+        "Target price mapped from percentile 55.34",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -910,17 +912,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 222.5,
-      "season_avg_points": 31.79,
+      "season_total_points": 212,
+      "season_avg_points": 30.29,
       "recent_avg_points": 11,
       "last_match_points": -5,
-      "score_basis": 19.32,
+      "score_basis": 18.72,
       "reliability_factor": 1,
-      "adjusted_score": 19.32,
-      "percentile": 61.26,
+      "adjusted_score": 18.72,
+      "percentile": 60.08,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 61.26",
+        "Target price mapped from percentile 60.08",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -941,15 +943,15 @@
       "matches_played": 7,
       "season_total_points": 197,
       "season_avg_points": 28.14,
-      "recent_avg_points": 6.67,
-      "last_match_points": 0,
-      "score_basis": 15.26,
+      "recent_avg_points": 9.67,
+      "last_match_points": 9,
+      "score_basis": 17.06,
       "reliability_factor": 1,
-      "adjusted_score": 15.26,
-      "percentile": 56.13,
+      "adjusted_score": 17.06,
+      "percentile": 57.71,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.13",
+        "Target price mapped from percentile 57.71",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -968,13 +970,13 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 223,
-      "season_avg_points": 37.17,
+      "season_total_points": 228,
+      "season_avg_points": 38,
       "recent_avg_points": 5.33,
       "last_match_points": 8,
-      "score_basis": 18.07,
+      "score_basis": 18.4,
       "reliability_factor": 1,
-      "adjusted_score": 18.07,
+      "adjusted_score": 18.4,
       "percentile": 59.29,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -999,15 +1001,15 @@
       "matches_played": 7,
       "season_total_points": 138.5,
       "season_avg_points": 19.79,
-      "recent_avg_points": 1.33,
-      "last_match_points": 0,
-      "score_basis": 8.71,
+      "recent_avg_points": 2.83,
+      "last_match_points": 4.5,
+      "score_basis": 9.61,
       "reliability_factor": 1,
-      "adjusted_score": 8.71,
-      "percentile": 46.25,
+      "adjusted_score": 9.61,
+      "percentile": 47.04,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 46.25",
+        "Target price mapped from percentile 47.04",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
@@ -1033,7 +1035,7 @@
       "score_basis": 31,
       "reliability_factor": 0.25,
       "adjusted_score": 7.75,
-      "percentile": 45.45,
+      "percentile": 45.06,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1048,23 +1050,21 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 41.5,
-      "season_avg_points": 8.3,
-      "recent_avg_points": 6.33,
-      "last_match_points": -5,
-      "score_basis": 7.12,
+      "season_total_points": 52,
+      "season_avg_points": 10.4,
+      "recent_avg_points": 9.83,
+      "last_match_points": 5.5,
+      "score_basis": 10.06,
       "reliability_factor": 1,
-      "adjusted_score": 7.12,
-      "percentile": 44.66,
+      "adjusted_score": 10.06,
+      "percentile": 47.83,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 44.66",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-21T14:00:00"
     },
@@ -1089,7 +1089,7 @@
       "score_basis": 11.1,
       "reliability_factor": 1,
       "adjusted_score": 11.1,
-      "percentile": 51.78,
+      "percentile": 50.99,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1228,7 +1228,7 @@
       "score_basis": 5,
       "reliability_factor": 0.25,
       "adjusted_score": 1.25,
-      "percentile": 39.13,
+      "percentile": 38.74,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1416,17 +1416,17 @@
       "final_price": 5,
       "price_change": 0,
       "matches_played": 3,
-      "season_total_points": 8,
-      "season_avg_points": 2.67,
-      "recent_avg_points": 2.67,
-      "last_match_points": -5,
-      "score_basis": 2.67,
+      "season_total_points": 13,
+      "season_avg_points": 4.33,
+      "recent_avg_points": 4.33,
+      "last_match_points": 0,
+      "score_basis": 4.33,
       "reliability_factor": 0.75,
-      "adjusted_score": 2,
-      "percentile": 41.5,
+      "adjusted_score": 3.25,
+      "percentile": 42.69,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 41.5",
+        "Target price mapped from percentile 42.69",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -1476,11 +1476,11 @@
       "matches_played": 7,
       "season_total_points": 348.5,
       "season_avg_points": 49.79,
-      "recent_avg_points": 61.33,
-      "last_match_points": 87,
-      "score_basis": 56.71,
+      "recent_avg_points": 66.33,
+      "last_match_points": 102,
+      "score_basis": 59.71,
       "reliability_factor": 1,
-      "adjusted_score": 56.71,
+      "adjusted_score": 59.71,
       "percentile": 96.05,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -1505,11 +1505,11 @@
       "matches_played": 7,
       "season_total_points": 359,
       "season_avg_points": 51.29,
-      "recent_avg_points": 49.67,
-      "last_match_points": 15,
-      "score_basis": 50.32,
+      "recent_avg_points": 51.67,
+      "last_match_points": 21,
+      "score_basis": 51.52,
       "reliability_factor": 1,
-      "adjusted_score": 50.32,
+      "adjusted_score": 51.52,
       "percentile": 90.91,
       "calculation_notes": [
         "Used old_price for smoothing"
@@ -1559,14 +1559,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 188.5,
-      "season_avg_points": 26.93,
-      "recent_avg_points": 23.67,
-      "last_match_points": -4,
-      "score_basis": 24.97,
+      "season_total_points": 193.5,
+      "season_avg_points": 27.64,
+      "recent_avg_points": 27.67,
+      "last_match_points": 8,
+      "score_basis": 27.66,
       "reliability_factor": 1,
-      "adjusted_score": 24.97,
-      "percentile": 68.38,
+      "adjusted_score": 27.66,
+      "percentile": 70.75,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1581,7 +1581,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -1593,9 +1593,11 @@
       "score_basis": 22.13,
       "reliability_factor": 1,
       "adjusted_score": 22.13,
-      "percentile": 65.22,
+      "percentile": 64.82,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 64.82",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -1615,15 +1617,15 @@
       "matches_played": 7,
       "season_total_points": 246.5,
       "season_avg_points": 35.21,
-      "recent_avg_points": 37.33,
-      "last_match_points": 20,
-      "score_basis": 36.48,
+      "recent_avg_points": 42.83,
+      "last_match_points": 36.5,
+      "score_basis": 39.78,
       "reliability_factor": 1,
-      "adjusted_score": 36.48,
-      "percentile": 80.63,
+      "adjusted_score": 39.78,
+      "percentile": 84.19,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 80.63",
+        "Target price mapped from percentile 84.19",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -1644,15 +1646,15 @@
       "matches_played": 7,
       "season_total_points": 254,
       "season_avg_points": 36.29,
-      "recent_avg_points": 8.67,
-      "last_match_points": 6,
-      "score_basis": 19.72,
+      "recent_avg_points": 11.17,
+      "last_match_points": 13.5,
+      "score_basis": 21.22,
       "reliability_factor": 1,
-      "adjusted_score": 19.72,
-      "percentile": 61.66,
+      "adjusted_score": 21.22,
+      "percentile": 64.03,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 61.66",
+        "Target price mapped from percentile 64.03",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -1707,10 +1709,10 @@
       "score_basis": 10.32,
       "reliability_factor": 1,
       "adjusted_score": 10.32,
-      "percentile": 49.41,
+      "percentile": 48.62,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 49.41",
+        "Target price mapped from percentile 48.62",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -1731,12 +1733,12 @@
       "matches_played": 7,
       "season_total_points": 219,
       "season_avg_points": 31.29,
-      "recent_avg_points": 26.67,
-      "last_match_points": 31,
-      "score_basis": 28.52,
+      "recent_avg_points": 27.17,
+      "last_match_points": 32.5,
+      "score_basis": 28.82,
       "reliability_factor": 1,
-      "adjusted_score": 28.52,
-      "percentile": 72.33,
+      "adjusted_score": 28.82,
+      "percentile": 72.73,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -1749,12 +1751,12 @@
       "role": "wicket_keeper",
       "is_uncapped": true,
       "pricing_eligible": true,
-      "old_price": 7,
-      "initial_price": 7,
+      "old_price": 8,
+      "initial_price": 8,
       "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
-      "price_change": 0,
+      "price_change": -1,
       "matches_played": 1,
       "season_total_points": 26,
       "season_avg_points": 26,
@@ -1763,10 +1765,10 @@
       "score_basis": 26,
       "reliability_factor": 0.25,
       "adjusted_score": 6.5,
-      "percentile": 44.27,
+      "percentile": 44.07,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 44.27",
+        "Target price mapped from percentile 44.07",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T00:00:00"
@@ -1792,7 +1794,7 @@
       "score_basis": 9.73,
       "reliability_factor": 1,
       "adjusted_score": 9.73,
-      "percentile": 47.83,
+      "percentile": 47.43,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2155,10 +2157,10 @@
       "score_basis": 25.54,
       "reliability_factor": 1,
       "adjusted_score": 25.54,
-      "percentile": 69.17,
+      "percentile": 68.77,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 69.17",
+        "Target price mapped from percentile 68.77",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2206,17 +2208,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 194,
-      "season_avg_points": 27.71,
-      "recent_avg_points": 10,
+      "season_total_points": 199,
+      "season_avg_points": 28.43,
+      "recent_avg_points": 11.67,
       "last_match_points": 3,
-      "score_basis": 17.08,
+      "score_basis": 18.37,
       "reliability_factor": 1,
-      "adjusted_score": 17.08,
-      "percentile": 58.5,
+      "adjusted_score": 18.37,
+      "percentile": 58.89,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 58.5",
+        "Target price mapped from percentile 58.89",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2262,17 +2264,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 8,
-      "season_total_points": 256,
-      "season_avg_points": 32,
-      "recent_avg_points": 48.33,
-      "last_match_points": 40,
-      "score_basis": 41.8,
+      "season_total_points": 263.5,
+      "season_avg_points": 32.94,
+      "recent_avg_points": 50.83,
+      "last_match_points": 47.5,
+      "score_basis": 43.67,
       "reliability_factor": 1,
-      "adjusted_score": 41.8,
-      "percentile": 86.96,
+      "adjusted_score": 43.67,
+      "percentile": 87.35,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 86.96",
+        "Target price mapped from percentile 87.35",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2298,10 +2300,10 @@
       "score_basis": 10.96,
       "reliability_factor": 1,
       "adjusted_score": 10.96,
-      "percentile": 50.59,
+      "percentile": 49.8,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 50.59",
+        "Target price mapped from percentile 49.8",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-14T14:00:00"
@@ -2320,17 +2322,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 278.5,
-      "season_avg_points": 39.79,
-      "recent_avg_points": 48,
-      "last_match_points": 80,
-      "score_basis": 44.72,
+      "season_total_points": 298,
+      "season_avg_points": 42.57,
+      "recent_avg_points": 54.5,
+      "last_match_points": 99.5,
+      "score_basis": 49.73,
       "reliability_factor": 1,
-      "adjusted_score": 44.72,
-      "percentile": 87.75,
+      "adjusted_score": 49.73,
+      "percentile": 90.51,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 87.75",
+        "Target price mapped from percentile 90.51",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2356,7 +2358,7 @@
       "score_basis": 26.74,
       "reliability_factor": 1,
       "adjusted_score": 26.74,
-      "percentile": 71.15,
+      "percentile": 69.57,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2398,7 +2400,7 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 9,
+      "target_price": 8,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
@@ -2410,11 +2412,9 @@
       "score_basis": 36.5,
       "reliability_factor": 1,
       "adjusted_score": 36.5,
-      "percentile": 81.03,
+      "percentile": 79.84,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 81.03",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
     },
@@ -2432,17 +2432,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 275.5,
-      "season_avg_points": 39.36,
-      "recent_avg_points": 40,
-      "last_match_points": 45,
-      "score_basis": 39.74,
+      "season_total_points": 295,
+      "season_avg_points": 42.14,
+      "recent_avg_points": 46.5,
+      "last_match_points": 64.5,
+      "score_basis": 44.76,
       "reliability_factor": 1,
-      "adjusted_score": 39.74,
-      "percentile": 85.77,
+      "adjusted_score": 44.76,
+      "percentile": 88.14,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 85.77",
+        "Target price mapped from percentile 88.14",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2456,23 +2456,21 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 7,
+      "target_price": 8,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 207.5,
-      "season_avg_points": 29.64,
-      "recent_avg_points": 14.33,
-      "last_match_points": 0,
-      "score_basis": 20.45,
+      "season_total_points": 216.5,
+      "season_avg_points": 30.93,
+      "recent_avg_points": 17.33,
+      "last_match_points": 9,
+      "score_basis": 22.77,
       "reliability_factor": 1,
-      "adjusted_score": 20.45,
-      "percentile": 63.24,
+      "adjusted_score": 22.77,
+      "percentile": 66.4,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 63.24",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
     },
@@ -2490,17 +2488,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 166,
-      "season_avg_points": 27.67,
-      "recent_avg_points": 40,
-      "last_match_points": 80,
-      "score_basis": 35.07,
+      "season_total_points": 185.5,
+      "season_avg_points": 30.92,
+      "recent_avg_points": 46.5,
+      "last_match_points": 99.5,
+      "score_basis": 40.27,
       "reliability_factor": 1,
-      "adjusted_score": 35.07,
-      "percentile": 80.24,
+      "adjusted_score": 40.27,
+      "percentile": 84.98,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 80.24",
+        "Target price mapped from percentile 84.98",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -2526,10 +2524,10 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 40.71,
+      "percentile": 40.32,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 40.71",
+        "Target price mapped from percentile 40.32",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-03-29T00:00:00"
@@ -2543,21 +2541,23 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 7,
+      "target_price": 6,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 38,
-      "season_avg_points": 19,
-      "recent_avg_points": 19,
-      "last_match_points": 15,
-      "score_basis": 19,
+      "season_total_points": 26,
+      "season_avg_points": 13,
+      "recent_avg_points": 13,
+      "last_match_points": 3,
+      "score_basis": 13,
       "reliability_factor": 0.5,
-      "adjusted_score": 9.5,
-      "percentile": 47.43,
+      "adjusted_score": 6.5,
+      "percentile": 44.07,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 44.07",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
     },
@@ -2827,17 +2827,17 @@
       "final_price": 5,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 4,
-      "season_avg_points": 2,
-      "recent_avg_points": 2,
-      "last_match_points": -5,
-      "score_basis": 2,
+      "season_total_points": 9,
+      "season_avg_points": 4.5,
+      "recent_avg_points": 4.5,
+      "last_match_points": 0,
+      "score_basis": 4.5,
       "reliability_factor": 0.5,
-      "adjusted_score": 1,
-      "percentile": 38.74,
+      "adjusted_score": 2.25,
+      "percentile": 41.5,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 38.74",
+        "Target price mapped from percentile 41.5",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-09T14:00:00"
@@ -2863,7 +2863,7 @@
       "score_basis": 37.43,
       "reliability_factor": 1,
       "adjusted_score": 37.43,
-      "percentile": 83.99,
+      "percentile": 82.02,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2882,15 +2882,15 @@
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
-      "matches_played": 7,
-      "season_total_points": 323,
-      "season_avg_points": 46.14,
-      "recent_avg_points": 44.67,
-      "last_match_points": 45,
-      "score_basis": 45.26,
+      "matches_played": 8,
+      "season_total_points": 333.5,
+      "season_avg_points": 41.69,
+      "recent_avg_points": 42.33,
+      "last_match_points": 49.5,
+      "score_basis": 42.07,
       "reliability_factor": 1,
-      "adjusted_score": 45.26,
-      "percentile": 88.54,
+      "adjusted_score": 42.07,
+      "percentile": 86.56,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -2910,17 +2910,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 76,
-      "season_avg_points": 15.2,
-      "recent_avg_points": 3.33,
-      "last_match_points": -5,
-      "score_basis": 8.08,
+      "season_total_points": 81,
+      "season_avg_points": 16.2,
+      "recent_avg_points": 5,
+      "last_match_points": 0,
+      "score_basis": 9.48,
       "reliability_factor": 1,
-      "adjusted_score": 8.08,
-      "percentile": 45.85,
+      "adjusted_score": 9.48,
+      "percentile": 46.64,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 45.85",
+        "Target price mapped from percentile 46.64",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-15T14:00:00"
@@ -2938,18 +2938,18 @@
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 6,
-      "season_total_points": 159.5,
-      "season_avg_points": 26.58,
-      "recent_avg_points": 17,
-      "last_match_points": -5,
-      "score_basis": 20.83,
+      "matches_played": 7,
+      "season_total_points": 162.5,
+      "season_avg_points": 23.21,
+      "recent_avg_points": 17.17,
+      "last_match_points": -0.5,
+      "score_basis": 19.59,
       "reliability_factor": 1,
-      "adjusted_score": 20.83,
-      "percentile": 64.03,
+      "adjusted_score": 19.59,
+      "percentile": 62.06,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.03",
+        "Target price mapped from percentile 62.06",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3002,10 +3002,10 @@
       "score_basis": 36.67,
       "reliability_factor": 1,
       "adjusted_score": 36.67,
-      "percentile": 81.42,
+      "percentile": 80.24,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 81.42",
+        "Target price mapped from percentile 80.24",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3023,14 +3023,14 @@
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
-      "matches_played": 3,
-      "season_total_points": 82,
-      "season_avg_points": 27.33,
-      "recent_avg_points": 27.33,
-      "last_match_points": 15,
-      "score_basis": 27.33,
-      "reliability_factor": 0.75,
-      "adjusted_score": 20.5,
+      "matches_played": 4,
+      "season_total_points": 91,
+      "season_avg_points": 22.75,
+      "recent_avg_points": 19.83,
+      "last_match_points": 19.5,
+      "score_basis": 21,
+      "reliability_factor": 1,
+      "adjusted_score": 21,
       "percentile": 63.64,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -3060,7 +3060,7 @@
       "score_basis": 32.4,
       "reliability_factor": 1,
       "adjusted_score": 32.4,
-      "percentile": 77.08,
+      "percentile": 77.47,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3087,7 +3087,7 @@
       "score_basis": 32.87,
       "reliability_factor": 1,
       "adjusted_score": 32.87,
-      "percentile": 78.26,
+      "percentile": 78.66,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3142,7 +3142,7 @@
       "score_basis": 20.32,
       "reliability_factor": 1,
       "adjusted_score": 20.32,
-      "percentile": 62.85,
+      "percentile": 63.24,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3169,7 +3169,7 @@
       "score_basis": 12.33,
       "reliability_factor": 0.75,
       "adjusted_score": 9.25,
-      "percentile": 47.04,
+      "percentile": 46.25,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3196,10 +3196,10 @@
       "score_basis": 4.5,
       "reliability_factor": 0.5,
       "adjusted_score": 2.25,
-      "percentile": 42.09,
+      "percentile": 41.5,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 42.09",
+        "Target price mapped from percentile 41.5",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3220,15 +3220,15 @@
       "matches_played": 4,
       "season_total_points": 124.5,
       "season_avg_points": 31.13,
-      "recent_avg_points": 31,
-      "last_match_points": 43,
-      "score_basis": 31.05,
+      "recent_avg_points": 32,
+      "last_match_points": 46,
+      "score_basis": 31.65,
       "reliability_factor": 1,
-      "adjusted_score": 31.05,
-      "percentile": 75.89,
+      "adjusted_score": 31.65,
+      "percentile": 76.09,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 75.89",
+        "Target price mapped from percentile 76.09",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -3242,23 +3242,21 @@
       "pricing_eligible": true,
       "old_price": 7,
       "initial_price": 7,
-      "target_price": 8,
+      "target_price": 7,
       "smoothed_price": 7,
       "final_price": 7,
       "price_change": 0,
-      "matches_played": 7,
-      "season_total_points": 236,
-      "season_avg_points": 33.71,
-      "recent_avg_points": 17.33,
+      "matches_played": 8,
+      "season_total_points": 247,
+      "season_avg_points": 30.88,
+      "recent_avg_points": 10.67,
       "last_match_points": 23,
-      "score_basis": 23.88,
+      "score_basis": 18.75,
       "reliability_factor": 1,
-      "adjusted_score": 23.88,
-      "percentile": 67.19,
+      "adjusted_score": 18.75,
+      "percentile": 60.47,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 67.19",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
     },
@@ -3283,7 +3281,7 @@
       "score_basis": 13,
       "reliability_factor": 1,
       "adjusted_score": 13,
-      "percentile": 52.96,
+      "percentile": 51.78,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3562,10 +3560,10 @@
       "score_basis": 2.75,
       "reliability_factor": 0.5,
       "adjusted_score": 1.38,
-      "percentile": 39.53,
+      "percentile": 39.13,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 39.53",
+        "Target price mapped from percentile 39.13",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-01T00:00:00"
@@ -3579,23 +3577,21 @@
       "pricing_eligible": true,
       "old_price": 9,
       "initial_price": 9,
-      "target_price": 8,
+      "target_price": 9,
       "smoothed_price": 9,
       "final_price": 9,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 138,
-      "season_avg_points": 69,
-      "recent_avg_points": 69,
-      "last_match_points": 117,
-      "score_basis": 69,
+      "season_total_points": 159,
+      "season_avg_points": 79.5,
+      "recent_avg_points": 79.5,
+      "last_match_points": 138,
+      "score_basis": 79.5,
       "reliability_factor": 0.5,
-      "adjusted_score": 34.5,
-      "percentile": 79.45,
+      "adjusted_score": 39.75,
+      "percentile": 83.79,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 79.45",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -3620,7 +3616,7 @@
       "score_basis": 51.53,
       "reliability_factor": 1,
       "adjusted_score": 51.53,
-      "percentile": 91.7,
+      "percentile": 91.3,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3705,10 +3701,10 @@
       "score_basis": 26.96,
       "reliability_factor": 1,
       "adjusted_score": 26.96,
-      "percentile": 71.54,
+      "percentile": 69.96,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 71.54",
+        "Target price mapped from percentile 69.96",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00"
@@ -3729,15 +3725,15 @@
       "matches_played": 5,
       "season_total_points": 159,
       "season_avg_points": 31.8,
-      "recent_avg_points": 40.67,
-      "last_match_points": 45,
-      "score_basis": 37.12,
+      "recent_avg_points": 45.67,
+      "last_match_points": 60,
+      "score_basis": 40.12,
       "reliability_factor": 1,
-      "adjusted_score": 37.12,
-      "percentile": 83,
+      "adjusted_score": 40.12,
+      "percentile": 84.58,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 83",
+        "Target price mapped from percentile 84.58",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3763,10 +3759,10 @@
       "score_basis": 17.5,
       "reliability_factor": 0.5,
       "adjusted_score": 8.75,
-      "percentile": 46.64,
+      "percentile": 45.85,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 46.64",
+        "Target price mapped from percentile 45.85",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-04T00:00:00"
@@ -3787,15 +3783,15 @@
       "matches_played": 6,
       "season_total_points": 207,
       "season_avg_points": 34.5,
-      "recent_avg_points": 39.67,
-      "last_match_points": 30,
-      "score_basis": 37.6,
+      "recent_avg_points": 40.67,
+      "last_match_points": 33,
+      "score_basis": 38.2,
       "reliability_factor": 1,
-      "adjusted_score": 37.6,
-      "percentile": 84.98,
+      "adjusted_score": 38.2,
+      "percentile": 83,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 84.98",
+        "Target price mapped from percentile 83",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3816,15 +3812,15 @@
       "matches_played": 4,
       "season_total_points": 149,
       "season_avg_points": 37.25,
-      "recent_avg_points": 37.67,
-      "last_match_points": 48,
-      "score_basis": 37.5,
+      "recent_avg_points": 41.17,
+      "last_match_points": 58.5,
+      "score_basis": 39.6,
       "reliability_factor": 1,
-      "adjusted_score": 37.5,
-      "percentile": 84.58,
+      "adjusted_score": 39.6,
+      "percentile": 83.4,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 84.58",
+        "Target price mapped from percentile 83.4",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3850,10 +3846,10 @@
       "score_basis": 45.6,
       "reliability_factor": 1,
       "adjusted_score": 45.6,
-      "percentile": 88.93,
+      "percentile": 88.54,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 88.93",
+        "Target price mapped from percentile 88.54",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -3893,12 +3889,12 @@
       "role": "all_rounder",
       "is_uncapped": false,
       "pricing_eligible": true,
-      "old_price": 8,
-      "initial_price": 8,
+      "old_price": 9,
+      "initial_price": 9,
       "target_price": 7,
       "smoothed_price": 8,
       "final_price": 8,
-      "price_change": 0,
+      "price_change": -1,
       "matches_played": 6,
       "season_total_points": 145.5,
       "season_avg_points": 24.25,
@@ -3907,10 +3903,10 @@
       "score_basis": 20.3,
       "reliability_factor": 1,
       "adjusted_score": 20.3,
-      "percentile": 62.45,
+      "percentile": 62.85,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 62.45",
+        "Target price mapped from percentile 62.85",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-16T14:00:00"
@@ -3936,7 +3932,7 @@
       "score_basis": 25.47,
       "reliability_factor": 1,
       "adjusted_score": 25.47,
-      "percentile": 68.77,
+      "percentile": 68.38,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -3951,23 +3947,21 @@
       "pricing_eligible": true,
       "old_price": 8,
       "initial_price": 8,
-      "target_price": 7,
+      "target_price": 8,
       "smoothed_price": 8,
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 148,
-      "season_avg_points": 24.67,
-      "recent_avg_points": 19,
+      "season_total_points": 153,
+      "season_avg_points": 25.5,
+      "recent_avg_points": 20.67,
       "last_match_points": 19,
-      "score_basis": 21.27,
+      "score_basis": 22.6,
       "reliability_factor": 1,
-      "adjusted_score": 21.27,
-      "percentile": 64.43,
+      "adjusted_score": 22.6,
+      "percentile": 66.01,
       "calculation_notes": [
-        "Used old_price for smoothing",
-        "Target price mapped from percentile 64.43",
-        "Applied smoothing against the target price"
+        "Used old_price for smoothing"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -3992,7 +3986,7 @@
       "score_basis": 10.35,
       "reliability_factor": 1,
       "adjusted_score": 10.35,
-      "percentile": 49.8,
+      "percentile": 49.01,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4019,10 +4013,10 @@
       "score_basis": 1.65,
       "reliability_factor": 1,
       "adjusted_score": 1.65,
-      "percentile": 39.92,
+      "percentile": 39.53,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 39.92",
+        "Target price mapped from percentile 39.53",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-12T14:00:00"
@@ -4096,17 +4090,17 @@
       "final_price": 6,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 99.5,
-      "season_avg_points": 14.21,
-      "recent_avg_points": 7.67,
-      "last_match_points": 28,
-      "score_basis": 10.29,
+      "season_total_points": 104.5,
+      "season_avg_points": 14.93,
+      "recent_avg_points": 14.83,
+      "last_match_points": 44.5,
+      "score_basis": 14.87,
       "reliability_factor": 1,
-      "adjusted_score": 10.29,
-      "percentile": 49.01,
+      "adjusted_score": 14.87,
+      "percentile": 54.94,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 49.01",
+        "Target price mapped from percentile 54.94",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
@@ -4120,21 +4114,23 @@
       "pricing_eligible": true,
       "old_price": 6,
       "initial_price": 6,
-      "target_price": 6,
+      "target_price": 7,
       "smoothed_price": 6,
       "final_price": 6,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 25,
-      "season_avg_points": 12.5,
-      "recent_avg_points": 12.5,
-      "last_match_points": 16,
-      "score_basis": 12.5,
+      "season_total_points": 34,
+      "season_avg_points": 17,
+      "recent_avg_points": 17,
+      "last_match_points": 25,
+      "score_basis": 17,
       "reliability_factor": 0.5,
-      "adjusted_score": 6.25,
-      "percentile": 43.48,
+      "adjusted_score": 8.5,
+      "percentile": 45.45,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Target price mapped from percentile 45.45",
+        "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-20T14:00:00"
     },
@@ -4187,7 +4183,7 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 40.71,
+      "percentile": 40.32,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4242,7 +4238,7 @@
       "score_basis": 6.3,
       "reliability_factor": 1,
       "adjusted_score": 6.3,
-      "percentile": 43.87,
+      "percentile": 43.48,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4433,15 +4429,15 @@
       "matches_played": 7,
       "season_total_points": 220.5,
       "season_avg_points": 31.5,
-      "recent_avg_points": 46,
-      "last_match_points": 15,
-      "score_basis": 40.2,
+      "recent_avg_points": 50,
+      "last_match_points": 27,
+      "score_basis": 42.6,
       "reliability_factor": 1,
-      "adjusted_score": 40.2,
-      "percentile": 86.17,
+      "adjusted_score": 42.6,
+      "percentile": 86.96,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 86.17",
+        "Target price mapped from percentile 86.96",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4462,12 +4458,12 @@
       "matches_played": 6,
       "season_total_points": 185,
       "season_avg_points": 30.83,
-      "recent_avg_points": 23.67,
-      "last_match_points": 41,
-      "score_basis": 26.53,
+      "recent_avg_points": 26.67,
+      "last_match_points": 50,
+      "score_basis": 28.33,
       "reliability_factor": 1,
-      "adjusted_score": 26.53,
-      "percentile": 70.75,
+      "adjusted_score": 28.33,
+      "percentile": 71.94,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4494,10 +4490,10 @@
       "score_basis": 18,
       "reliability_factor": 1,
       "adjusted_score": 18,
-      "percentile": 58.89,
+      "percentile": 58.5,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 58.89",
+        "Target price mapped from percentile 58.5",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4543,17 +4539,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 173.5,
-      "season_avg_points": 28.92,
-      "recent_avg_points": 4,
+      "season_total_points": 165,
+      "season_avg_points": 27.5,
+      "recent_avg_points": 5.67,
       "last_match_points": 22,
-      "score_basis": 13.97,
+      "score_basis": 14.4,
       "reliability_factor": 1,
-      "adjusted_score": 13.97,
-      "percentile": 54.55,
+      "adjusted_score": 14.4,
+      "percentile": 54.15,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 54.55",
+        "Target price mapped from percentile 54.15",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4574,12 +4570,12 @@
       "matches_played": 7,
       "season_total_points": 189.5,
       "season_avg_points": 27.07,
-      "recent_avg_points": 19.33,
-      "last_match_points": 11,
-      "score_basis": 22.43,
+      "recent_avg_points": 22.33,
+      "last_match_points": 20,
+      "score_basis": 24.23,
       "reliability_factor": 1,
-      "adjusted_score": 22.43,
-      "percentile": 66.01,
+      "adjusted_score": 24.23,
+      "percentile": 67.59,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -4601,15 +4597,15 @@
       "matches_played": 6,
       "season_total_points": 126,
       "season_avg_points": 21,
-      "recent_avg_points": 6,
-      "last_match_points": 20,
-      "score_basis": 12,
+      "recent_avg_points": 8.5,
+      "last_match_points": 27.5,
+      "score_basis": 13.5,
       "reliability_factor": 1,
-      "adjusted_score": 12,
-      "percentile": 52.57,
+      "adjusted_score": 13.5,
+      "percentile": 53.16,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 52.57",
+        "Target price mapped from percentile 53.16",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T14:00:00"
@@ -4635,7 +4631,7 @@
       "score_basis": 18.76,
       "reliability_factor": 1,
       "adjusted_score": 18.76,
-      "percentile": 60.08,
+      "percentile": 60.87,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5138,7 +5134,7 @@
       "score_basis": 61,
       "reliability_factor": 0.75,
       "adjusted_score": 45.75,
-      "percentile": 89.33,
+      "percentile": 88.93,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5194,7 +5190,7 @@
       "score_basis": 37.43,
       "reliability_factor": 1,
       "adjusted_score": 37.43,
-      "percentile": 83.99,
+      "percentile": 82.02,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5221,10 +5217,10 @@
       "score_basis": 29.5,
       "reliability_factor": 0.75,
       "adjusted_score": 22.13,
-      "percentile": 64.82,
+      "percentile": 64.43,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 64.82",
+        "Target price mapped from percentile 64.43",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-10T14:00:00"
@@ -5250,10 +5246,10 @@
       "score_basis": 36.83,
       "reliability_factor": 1,
       "adjusted_score": 36.83,
-      "percentile": 81.82,
+      "percentile": 80.63,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 81.82",
+        "Target price mapped from percentile 80.63",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5279,10 +5275,10 @@
       "score_basis": 47.25,
       "reliability_factor": 1,
       "adjusted_score": 47.25,
-      "percentile": 89.72,
+      "percentile": 89.33,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 89.72",
+        "Target price mapped from percentile 89.33",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5308,10 +5304,10 @@
       "score_basis": 14.6,
       "reliability_factor": 1,
       "adjusted_score": 14.6,
-      "percentile": 55.34,
+      "percentile": 54.55,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 55.34",
+        "Target price mapped from percentile 54.55",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5330,17 +5326,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 124.5,
-      "season_avg_points": 24.9,
-      "recent_avg_points": 10,
-      "last_match_points": -5,
-      "score_basis": 15.96,
+      "season_total_points": 129.5,
+      "season_avg_points": 25.9,
+      "recent_avg_points": 11.67,
+      "last_match_points": 0,
+      "score_basis": 17.36,
       "reliability_factor": 1,
-      "adjusted_score": 15.96,
-      "percentile": 57.71,
+      "adjusted_score": 17.36,
+      "percentile": 58.1,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 57.71",
+        "Target price mapped from percentile 58.1",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5366,7 +5362,7 @@
       "score_basis": 18.93,
       "reliability_factor": 1,
       "adjusted_score": 18.93,
-      "percentile": 60.47,
+      "percentile": 61.26,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5393,10 +5389,10 @@
       "score_basis": 25.65,
       "reliability_factor": 1,
       "adjusted_score": 25.65,
-      "percentile": 69.57,
+      "percentile": 69.17,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 69.57",
+        "Target price mapped from percentile 69.17",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T10:00:00"
@@ -5422,7 +5418,7 @@
       "score_basis": 41,
       "reliability_factor": 0.25,
       "adjusted_score": 10.25,
-      "percentile": 48.62,
+      "percentile": 48.22,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5449,7 +5445,7 @@
       "score_basis": 8,
       "reliability_factor": 0.25,
       "adjusted_score": 2,
-      "percentile": 40.71,
+      "percentile": 40.32,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5721,17 +5717,17 @@
       "final_price": 10,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 296,
-      "season_avg_points": 49.33,
-      "recent_avg_points": 47,
-      "last_match_points": 25,
-      "score_basis": 47.93,
+      "season_total_points": 284,
+      "season_avg_points": 47.33,
+      "recent_avg_points": 43,
+      "last_match_points": 13,
+      "score_basis": 44.73,
       "reliability_factor": 1,
-      "adjusted_score": 47.93,
-      "percentile": 90.12,
+      "adjusted_score": 44.73,
+      "percentile": 87.75,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 90.12",
+        "Target price mapped from percentile 87.75",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5750,14 +5746,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 285,
-      "season_avg_points": 40.71,
-      "recent_avg_points": 35,
-      "last_match_points": 28,
-      "score_basis": 37.28,
+      "season_total_points": 298.5,
+      "season_avg_points": 42.64,
+      "recent_avg_points": 39.5,
+      "last_match_points": 41.5,
+      "score_basis": 40.76,
       "reliability_factor": 1,
-      "adjusted_score": 37.28,
-      "percentile": 83.4,
+      "adjusted_score": 40.76,
+      "percentile": 85.38,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5777,17 +5773,17 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 283.5,
-      "season_avg_points": 40.5,
-      "recent_avg_points": 16,
-      "last_match_points": 10,
-      "score_basis": 25.8,
+      "season_total_points": 291,
+      "season_avg_points": 41.57,
+      "recent_avg_points": 18.5,
+      "last_match_points": 17.5,
+      "score_basis": 27.73,
       "reliability_factor": 1,
-      "adjusted_score": 25.8,
-      "percentile": 70.16,
+      "adjusted_score": 27.73,
+      "percentile": 71.15,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 70.16",
+        "Target price mapped from percentile 71.15",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5806,14 +5802,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 236,
-      "season_avg_points": 39.33,
-      "recent_avg_points": 48.33,
-      "last_match_points": 57,
-      "score_basis": 44.73,
+      "season_total_points": 251,
+      "season_avg_points": 41.83,
+      "recent_avg_points": 53.33,
+      "last_match_points": 72,
+      "score_basis": 48.73,
       "reliability_factor": 1,
-      "adjusted_score": 44.73,
-      "percentile": 88.14,
+      "adjusted_score": 48.73,
+      "percentile": 89.72,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5868,10 +5864,10 @@
       "score_basis": 32.47,
       "reliability_factor": 1,
       "adjusted_score": 32.47,
-      "percentile": 77.47,
+      "percentile": 77.87,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 77.47",
+        "Target price mapped from percentile 77.87",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5890,14 +5886,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 4,
-      "season_total_points": 104,
-      "season_avg_points": 26,
-      "recent_avg_points": 25.67,
-      "last_match_points": 1,
-      "score_basis": 25.8,
+      "season_total_points": 110,
+      "season_avg_points": 27.5,
+      "recent_avg_points": 27.67,
+      "last_match_points": 7,
+      "score_basis": 27.6,
       "reliability_factor": 1,
-      "adjusted_score": 25.8,
-      "percentile": 70.16,
+      "adjusted_score": 27.6,
+      "percentile": 70.36,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -5924,10 +5920,10 @@
       "score_basis": 37,
       "reliability_factor": 1,
       "adjusted_score": 37,
-      "percentile": 82.21,
+      "percentile": 81.03,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 82.21",
+        "Target price mapped from percentile 81.03",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -5946,17 +5942,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 195,
-      "season_avg_points": 27.86,
-      "recent_avg_points": 6.67,
-      "last_match_points": 20,
-      "score_basis": 15.15,
+      "season_total_points": 201,
+      "season_avg_points": 28.71,
+      "recent_avg_points": 8.67,
+      "last_match_points": 26,
+      "score_basis": 16.69,
       "reliability_factor": 1,
-      "adjusted_score": 15.15,
-      "percentile": 55.73,
+      "adjusted_score": 16.69,
+      "percentile": 57.31,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 55.73",
+        "Target price mapped from percentile 57.31",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -6003,17 +5999,17 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 127.5,
-      "season_avg_points": 18.21,
-      "recent_avg_points": 14,
-      "last_match_points": 7,
-      "score_basis": 15.68,
+      "season_total_points": 129,
+      "season_avg_points": 18.43,
+      "recent_avg_points": 14.5,
+      "last_match_points": 8.5,
+      "score_basis": 16.07,
       "reliability_factor": 1,
-      "adjusted_score": 15.68,
-      "percentile": 56.92,
+      "adjusted_score": 16.07,
+      "percentile": 56.52,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 56.92",
+        "Target price mapped from percentile 56.52",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -6039,10 +6035,10 @@
       "score_basis": 19.9,
       "reliability_factor": 1,
       "adjusted_score": 19.9,
-      "percentile": 62.06,
+      "percentile": 62.45,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 62.06",
+        "Target price mapped from percentile 62.45",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-13T14:00:00"
@@ -6068,10 +6064,10 @@
       "score_basis": 15.9,
       "reliability_factor": 1,
       "adjusted_score": 15.9,
-      "percentile": 57.31,
+      "percentile": 56.13,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 57.31",
+        "Target price mapped from percentile 56.13",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-19T10:00:00"
@@ -6097,7 +6093,7 @@
       "score_basis": 31.65,
       "reliability_factor": 1,
       "adjusted_score": 31.65,
-      "percentile": 76.28,
+      "percentile": 76.09,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6117,14 +6113,14 @@
       "final_price": 7,
       "price_change": 0,
       "matches_played": 2,
-      "season_total_points": 40,
-      "season_avg_points": 20,
-      "recent_avg_points": 20,
-      "last_match_points": 25,
-      "score_basis": 20,
+      "season_total_points": 55,
+      "season_avg_points": 27.5,
+      "recent_avg_points": 27.5,
+      "last_match_points": 40,
+      "score_basis": 27.5,
       "reliability_factor": 0.5,
-      "adjusted_score": 10,
-      "percentile": 48.22,
+      "adjusted_score": 13.75,
+      "percentile": 53.75,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6450,17 +6446,17 @@
       "final_price": 10,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 351.5,
-      "season_avg_points": 58.58,
+      "season_total_points": 344,
+      "season_avg_points": 57.33,
       "recent_avg_points": 44,
       "last_match_points": 64,
-      "score_basis": 49.83,
+      "score_basis": 49.33,
       "reliability_factor": 1,
-      "adjusted_score": 49.83,
-      "percentile": 90.51,
+      "adjusted_score": 49.33,
+      "percentile": 90.12,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 90.51",
+        "Target price mapped from percentile 90.12",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6508,13 +6504,13 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 5,
-      "season_total_points": 163.5,
-      "season_avg_points": 32.7,
+      "season_total_points": 156,
+      "season_avg_points": 31.2,
       "recent_avg_points": 19.67,
       "last_match_points": -5,
-      "score_basis": 24.88,
+      "score_basis": 24.28,
       "reliability_factor": 1,
-      "adjusted_score": 24.88,
+      "adjusted_score": 24.28,
       "percentile": 67.98,
       "calculation_notes": [
         "Used old_price for smoothing",
@@ -6537,14 +6533,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 7,
-      "season_total_points": 341,
-      "season_avg_points": 48.71,
-      "recent_avg_points": 52,
+      "season_total_points": 346,
+      "season_avg_points": 49.43,
+      "recent_avg_points": 53.67,
       "last_match_points": 32,
-      "score_basis": 50.68,
+      "score_basis": 51.97,
       "reliability_factor": 1,
-      "adjusted_score": 50.68,
-      "percentile": 91.3,
+      "adjusted_score": 51.97,
+      "percentile": 91.7,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6600,7 +6596,7 @@
       "score_basis": 55.5,
       "reliability_factor": 0.75,
       "adjusted_score": 41.63,
-      "percentile": 86.56,
+      "percentile": 86.17,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6620,14 +6616,14 @@
       "final_price": 9,
       "price_change": 0,
       "matches_played": 3,
-      "season_total_points": 177.5,
-      "season_avg_points": 59.17,
-      "recent_avg_points": 59.17,
+      "season_total_points": 165.5,
+      "season_avg_points": 55.17,
+      "recent_avg_points": 55.17,
       "last_match_points": 20,
-      "score_basis": 59.17,
+      "score_basis": 55.17,
       "reliability_factor": 0.75,
-      "adjusted_score": 44.38,
-      "percentile": 87.35,
+      "adjusted_score": 41.38,
+      "percentile": 85.77,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6683,10 +6679,10 @@
       "score_basis": 16.4,
       "reliability_factor": 1,
       "adjusted_score": 16.4,
-      "percentile": 58.1,
+      "percentile": 56.92,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 58.1",
+        "Target price mapped from percentile 56.92",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6712,10 +6708,10 @@
       "score_basis": 21.75,
       "reliability_factor": 0.5,
       "adjusted_score": 10.88,
-      "percentile": 50.2,
+      "percentile": 49.41,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 50.2",
+        "Target price mapped from percentile 49.41",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-02T00:00:00"
@@ -6734,14 +6730,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 231,
-      "season_avg_points": 38.5,
+      "season_total_points": 216,
+      "season_avg_points": 36,
       "recent_avg_points": 29.67,
       "last_match_points": 74,
-      "score_basis": 33.2,
+      "score_basis": 32.2,
       "reliability_factor": 1,
-      "adjusted_score": 33.2,
-      "percentile": 78.66,
+      "adjusted_score": 32.2,
+      "percentile": 77.08,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6768,10 +6764,10 @@
       "score_basis": 22,
       "reliability_factor": 0.5,
       "adjusted_score": 11,
-      "percentile": 51.19,
+      "percentile": 50.4,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 51.19",
+        "Target price mapped from percentile 50.4",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6790,14 +6786,14 @@
       "final_price": 8,
       "price_change": 0,
       "matches_played": 6,
-      "season_total_points": 189.5,
-      "season_avg_points": 31.58,
+      "season_total_points": 186.5,
+      "season_avg_points": 31.08,
       "recent_avg_points": 37,
       "last_match_points": 39,
-      "score_basis": 34.83,
+      "score_basis": 34.63,
       "reliability_factor": 1,
-      "adjusted_score": 34.83,
-      "percentile": 79.84,
+      "adjusted_score": 34.63,
+      "percentile": 79.45,
       "calculation_notes": [
         "Used old_price for smoothing"
       ],
@@ -6853,10 +6849,10 @@
       "score_basis": 24,
       "reliability_factor": 1,
       "adjusted_score": 24,
-      "percentile": 67.59,
+      "percentile": 67.19,
       "calculation_notes": [
         "Used old_price for smoothing",
-        "Target price mapped from percentile 67.59",
+        "Target price mapped from percentile 67.19",
         "Applied smoothing against the target price"
       ],
       "last_match_played_at_utc": "2026-04-18T14:00:00"
@@ -6938,9 +6934,10 @@
       "score_basis": 12,
       "reliability_factor": 0.25,
       "adjusted_score": 3,
-      "percentile": 42.69,
+      "percentile": 42.29,
       "calculation_notes": [
-        "Used old_price for smoothing"
+        "Used old_price for smoothing",
+        "Recovered real match history from a previously blank price; used the corrected target price immediately"
       ],
       "last_match_played_at_utc": "2026-03-28T00:00:00"
     },
@@ -7169,5 +7166,5 @@
       "last_match_played_at_utc": null
     }
   ],
-  "generated_at_utc": "2026-04-22T08:03:42.012Z"
+  "generated_at_utc": "2026-04-21T21:13:00.688Z"
 }

--- a/scripts/update-live-data.mjs
+++ b/scripts/update-live-data.mjs
@@ -32,6 +32,8 @@ const LIVE_SCORECARD_INTERVAL_MINUTES = parseEnvInt(process.env.CRICKETDATA_LIVE
 const MAX_BACKLOG_SCORECARDS_PER_RUN = parseEnvInt(process.env.CRICKETDATA_MAX_BACKLOG_SCORECARDS_PER_RUN, 2);
 const MAX_FRESH_SCORECARD_CALLS_PER_RUN = parseEnvNonNegativeInt(process.env.CRICKETDATA_MAX_FRESH_SCORECARD_CALLS_PER_RUN, 1);
 const ALLOW_HISTORICAL_REPLAY_API = parseEnvBool(process.env.CRICKETDATA_ALLOW_HISTORICAL_REPLAY, false);
+const FORCE_REFETCH_SCORECARD_IDS = parseEnvList(process.env.CRICKETDATA_FORCE_REFETCH_SCORECARD_IDS);
+const FORCE_REFETCH_SCORECARD_ID_SET = new Set(FORCE_REFETCH_SCORECARD_IDS);
 const IPLT20_MOST_DOTS_ENABLED = parseEnvBool(process.env.IPLT20_MOST_DOTS_ENABLED, true);
 const IPLT20_MOST_DOTS_MIN_REFRESH_MINUTES = parseEnvInt(process.env.IPLT20_MOST_DOTS_MIN_REFRESH_MINUTES, 120);
 const IPLT20_MOST_DOTS_FEED_URL = 'https://ipl-stats-sports-mechanic.s3.ap-south-1.amazonaws.com/ipl/feeds/stats/284-mostdotballsbowledtournament.js?callback=onmostdotballsbowledtournament';
@@ -87,6 +89,13 @@ function parseEnvInt(value, fallback) {
 function parseEnvNonNegativeInt(value, fallback) {
   const n = Number.parseInt(String(value ?? ''), 10);
   return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function parseEnvList(value) {
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function buildSeriesInfoUrl(apiKey) {
@@ -505,6 +514,39 @@ export async function writeCachedScorecard(matchId, scorecard, { cacheDir = SCOR
     }, null, 2),
     'utf8'
   );
+}
+
+function scorecardInningsCount(scorecard) {
+  return safeArray(scorecard?.scorecard).length;
+}
+
+function topLevelScoreInningsCount(scorecard) {
+  return safeArray(scorecard?.score)
+    .filter((entry) => Number.isFinite(Number(entry?.r ?? entry?.runs)))
+    .length;
+}
+
+export function completedScorecardIntegrityIssues(scorecard) {
+  const issues = [];
+  if (!scorecard?.matchEnded) return issues;
+
+  const scoreInnings = topLevelScoreInningsCount(scorecard);
+  const scorecardInnings = scorecardInningsCount(scorecard);
+  if (scoreInnings >= 2 && scorecardInnings < scoreInnings) {
+    issues.push(`final score has ${scoreInnings} innings but scorecard has ${scorecardInnings}`);
+  }
+
+  return issues;
+}
+
+function assertCompletedScorecardCacheable(matchId, scorecard) {
+  const issues = completedScorecardIntegrityIssues(scorecard);
+  if (!issues.length) return;
+  const error = new Error(`Incomplete completed scorecard for ${matchId}: ${issues.join('; ')}`);
+  error.code = 'CRICKETDATA_INCOMPLETE_SCORECARD';
+  error.matchId = matchId;
+  error.integrityIssues = issues;
+  throw error;
 }
 
 export async function findMissingScorecardCaches(matchIds, { cacheDir = SCORECARD_CACHE_DIR } = {}) {
@@ -1893,7 +1935,7 @@ export async function rebuildHistoricalState(processedIds, baseLive = null, { in
 
     if (scorecardResult) {
       if (scorecardResult.source === 'cache') cacheHits += 1;
-      if (scorecardResult.source === 'api') apiCalls += 1;
+      if (isApiScorecardSource(scorecardResult.source)) apiCalls += 1;
       applyScorecardToAggregates(rebuilt, scorecardResult.data, { isFinal: true });
     }
     const historicalCumulativeDots = resolveHistoricalCumulativeDots(baseLive, processedMatchCount);
@@ -1973,7 +2015,7 @@ export async function repairScoreHistoryGaps(live, processedRefs, { loadScorecar
     }
 
     if (scorecardResult.source === 'cache') cacheHits += 1;
-    if (scorecardResult.source === 'api') apiCalls += 1;
+    if (isApiScorecardSource(scorecardResult.source)) apiCalls += 1;
 
     const nextAgg = cloneJson(previousAgg);
     applyScorecardToAggregates(nextAgg, scorecardResult.data, { isFinal: true });
@@ -2117,8 +2159,8 @@ function liveMatchCandidate(matchList) {
   return safeArray(matchList).find((m) => m.matchStarted && !m.matchEnded) || null;
 }
 
-async function processScorecard(matchId, live, { preferCache = false, allowApiFallback = true } = {}) {
-  if (preferCache) {
+async function processScorecard(matchId, live, { preferCache = false, allowApiFallback = true, forceRefresh = false } = {}) {
+  if (preferCache && !forceRefresh) {
     const cached = await readCachedScorecard(matchId);
     if (cached) return { data: cached, source: 'cache' };
     if (!allowApiFallback) {
@@ -2127,8 +2169,16 @@ async function processScorecard(matchId, live, { preferCache = false, allowApiFa
   }
 
   const json = await fetchCricketDataJson((apiKey) => buildScorecardUrl(apiKey, matchId), live);
+  assertCompletedScorecardCacheable(matchId, json.data);
   await writeCachedScorecard(matchId, json.data);
-  return { data: json.data, source: 'api' };
+  if (forceRefresh) {
+    live.meta.lastRun.forcedScorecardRefetches = Number(live.meta.lastRun.forcedScorecardRefetches || 0) + 1;
+  }
+  return { data: json.data, source: forceRefresh ? 'api-force-refresh' : 'api' };
+}
+
+function isApiScorecardSource(source) {
+  return source === 'api' || source === 'api-force-refresh';
 }
 
 function shouldFetchLiveScorecard(live, activeMatch, currentMs) {
@@ -2205,7 +2255,9 @@ async function main() {
     freshScorecardBudgetSkips: 0,
     deferredScorecards: 0,
     deferredScorecardMatchIds: [],
-    deferredScorecardReason: null
+    deferredScorecardReason: null,
+    forcedScorecardRefetchIds: FORCE_REFETCH_SCORECARD_IDS,
+    forcedScorecardRefetches: 0
   };
   live.meta.scorecardBudget.lastBudgetExhaustedAt = null;
   live.meta.scorecardBudget.lastBudgetSkipReason = null;
@@ -2277,15 +2329,23 @@ async function main() {
   const processedIds = new Set(processedRefs.map((match) => match?.id).filter(Boolean));
   const processedKeySet = new Set(processedMatchKeys);
   let finalizedAgg = live.meta.aggregates || createEmptyAggregates();
+  const forcedProcessedRefetchIds = processedRefs
+    .map((match) => match?.id)
+    .filter((matchId) => FORCE_REFETCH_SCORECARD_ID_SET.has(matchId));
 
   let requiresHistoricalBackfill = needsHistoricalAggregateBackfill(live);
   let requiresScoreHistoryBackfill = needsScoreHistoryBackfill(live);
+  if (forcedProcessedRefetchIds.length) {
+    requiresHistoricalBackfill = true;
+    requiresScoreHistoryBackfill = true;
+  }
 
   if (requiresScoreHistoryBackfill && processedRefs.length) {
     const gapRepair = await repairScoreHistoryGaps(live, processedRefs, {
       loadScorecard: (matchId) => processScorecard(matchId, live, {
         preferCache: true,
-        allowApiFallback: ALLOW_HISTORICAL_REPLAY_API
+        allowApiFallback: ALLOW_HISTORICAL_REPLAY_API,
+        forceRefresh: FORCE_REFETCH_SCORECARD_ID_SET.has(matchId)
       })
     });
     live.meta.lastRun.scorecardCalls += gapRepair.apiCalls;
@@ -2316,7 +2376,8 @@ async function main() {
             includeHistory: (requiresScoreHistoryBackfill || requiresHistoricalBackfill),
             loadScorecard: (matchId) => processScorecard(matchId, live, {
               preferCache: true,
-              allowApiFallback: ALLOW_HISTORICAL_REPLAY_API
+              allowApiFallback: ALLOW_HISTORICAL_REPLAY_API,
+              forceRefresh: FORCE_REFETCH_SCORECARD_ID_SET.has(matchId)
             })
           }
         );
@@ -2352,7 +2413,7 @@ async function main() {
     }
     let scorecardResult;
     try {
-      scorecardResult = await processScorecard(match.id, live, { preferCache: true });
+        scorecardResult = await processScorecard(match.id, live, { preferCache: true });
     } catch (error) {
       const missingScorecard = parseCricketDataScorecardNotFoundDetails(error);
       if (!missingScorecard) throw error;
@@ -2572,6 +2633,8 @@ async function main() {
       historicalReplayApiFallbackAllowed: ALLOW_HISTORICAL_REPLAY_API,
       scorecardCallsThisRun: live.meta.lastRun.scorecardCalls,
       scorecardCacheHitsThisRun: live.meta.lastRun.scorecardCacheHits,
+      forcedScorecardRefetchIds: live.meta.lastRun.forcedScorecardRefetchIds,
+      forcedScorecardRefetches: live.meta.lastRun.forcedScorecardRefetches,
       historicalReplaySkipped: live.meta.lastRun.historicalReplaySkipped,
       historicalReplayMissingCaches: live.meta.lastRun.historicalReplayMissingCaches,
       freshScorecardBudgetExhausted: live.meta.lastRun.freshScorecardBudgetExhausted,

--- a/tests/update-live-data.scorecard-cache.test.mjs
+++ b/tests/update-live-data.scorecard-cache.test.mjs
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict';
 import {
   endedUnprocessedMatches,
   canUseFreshScorecardCall,
+  completedScorecardIntegrityIssues,
   findMissingScorecardCaches,
   freshScorecardBudgetRemaining,
   inferProcessedMatchKeys,
@@ -149,6 +150,38 @@ test('fresh scorecard budget helper hard-stops paid calls once the run cap is re
   assert.equal(canUseFreshScorecardCall({ meta: { lastRun: { scorecardCalls: 0 } } }, 1, 2), true);
 });
 
+test('completed scorecard integrity check catches final-score shells with partial player scorecards', () => {
+  const partial = {
+    matchEnded: true,
+    score: [
+      { inning: 'Sunrisers Hyderabad Inning 1', r: 242, w: 2, o: 20 },
+      { inning: 'Delhi Capitals Inning 1', r: 195, w: 9, o: 20 }
+    ],
+    scorecard: [
+      {
+        inning: 'Sunrisers Hyderabad Inning 1',
+        batting: [{ batsman: { name: 'Abhishek Sharma' }, r: 75 }]
+      }
+    ]
+  };
+
+  assert.deepEqual(
+    completedScorecardIntegrityIssues(partial),
+    ['final score has 2 innings but scorecard has 1']
+  );
+
+  assert.deepEqual(
+    completedScorecardIntegrityIssues({
+      ...partial,
+      scorecard: [
+        ...partial.scorecard,
+        { inning: 'Delhi Capitals Inning 1', batting: [{ batsman: { name: 'KL Rahul' }, r: 37 }] }
+      ]
+    }),
+    []
+  );
+});
+
 test('historical rebuild tracks cache hits separately from paid API scorecard calls', async () => {
   const scorecards = {
     'match-1': makeFinalScorecard({
@@ -194,7 +227,7 @@ test('historical rebuild tracks cache hits separately from paid API scorecard ca
       includeHistory: true,
       loadScorecard: async (matchId) => ({
         data: scorecards[matchId],
-        source: matchId === 'match-1' ? 'cache' : 'api'
+        source: matchId === 'match-1' ? 'cache' : 'api-force-refresh'
       })
     }
   );


### PR DESCRIPTION
## Summary

Adds a targeted scorecard refetch path so Match 31 can be repaired from CricketData now that the fresh API response has the completed SRH vs DC scorecard.

This PR is tooling-only. It does **not** include the repaired data commit.

After this PR is merged into `main`, run the `Update live IPL data` workflow once on `main` in `refresh` mode with:

`force_refetch_scorecard_ids = e4f4995f-036e-451d-861e-42567c82d87f`

That single forced run should:

- Fetch the corrected Match 31 scorecard from CricketData even though a stale cache exists.
- Replace `data/scorecards/e4f4995f-036e-451d-861e-42567c82d87f.json`.
- Rebuild live aggregates, Mini Fantasy player histories, and prices from the corrected scorecard cache.
- Commit the repaired data back to `main`.
- Publish the corrected Mini Fantasy leaderboard snapshot to Supabase because publishing is main-only.

## Safety

- Branch workflow runs do not publish the Mini Fantasy leaderboard snapshot to Supabase. Publishing remains main-only.
- Fresh completed scorecards are now integrity-checked before caching. If CricketData returns a final top-level score with fewer nested scorecard innings, the worker rejects it instead of caching a partial final scorecard.

## Validation

- `node scripts/run-node-tests.mjs` passes: 96/96.

## Important

Do not run the workflow again until this PR is merged into `main`; GitHub only shows the new `force_refetch_scorecard_ids` input from the default branch workflow form.