### PR TITLE
Reject stale completed scorecards before caching

### DIFF
--- a/scripts/update-live-data.mjs
+++ b/scripts/update-live-data.mjs
@@ -526,15 +526,89 @@ function topLevelScoreInningsCount(scorecard) {
     .length;
 }
 
+function isNoResultScorecard(scorecard) {
+  const winnerText = normalizeName(scorecard?.matchWinner || '').toLowerCase();
+  const status = normalizeName(scorecard?.status || '').toLowerCase();
+  return (
+    winnerText === 'no winner' ||
+    status.includes('no result') ||
+    status.includes('abandon') ||
+    status.includes('abandoned') ||
+    status.includes('washout')
+  );
+}
+
+function scoreRuns(entry) {
+  const value = Number(entry?.r ?? entry?.runs);
+  return Number.isFinite(value) ? value : null;
+}
+
+function inningLabel(entry) {
+  return normalizeName(entry?.inning || entry?.name || '');
+}
+
+function battingRowsForIntegrity(innings) {
+  return safeArray(innings?.batting || innings?.batsman);
+}
+
+function bowlingRowsForIntegrity(innings) {
+  return safeArray(innings?.bowling || innings?.bowler);
+}
+
+function scoreEntryForInnings(scoreEntries, innings, index) {
+  const label = inningLabel(innings);
+  if (label) {
+    const exact = scoreEntries.find((entry) => inningLabel(entry) === label);
+    if (exact) return exact;
+  }
+  return scoreEntries[index] || null;
+}
+
+function sumNumeric(rows, pickValue) {
+  return safeArray(rows).reduce((sum, row) => {
+    const value = Number(pickValue(row) || 0);
+    return Number.isFinite(value) ? sum + value : sum;
+  }, 0);
+}
+
 export function completedScorecardIntegrityIssues(scorecard) {
   const issues = [];
   if (!scorecard?.matchEnded) return issues;
+  if (isNoResultScorecard(scorecard)) return issues;
 
-  const scoreInnings = topLevelScoreInningsCount(scorecard);
+  const scoreEntries = safeArray(scorecard?.score)
+    .filter((entry) => Number.isFinite(Number(entry?.r ?? entry?.runs)));
+  const scoreInnings = scoreEntries.length;
   const scorecardInnings = scorecardInningsCount(scorecard);
   if (scoreInnings >= 2 && scorecardInnings < scoreInnings) {
     issues.push(`final score has ${scoreInnings} innings but scorecard has ${scorecardInnings}`);
   }
+
+  safeArray(scorecard?.scorecard).forEach((innings, index) => {
+    const scoreEntry = scoreEntryForInnings(scoreEntries, innings, index);
+    const topRuns = scoreRuns(scoreEntry);
+    if (topRuns === null) return;
+
+    const battingRuns = sumNumeric(battingRowsForIntegrity(innings), (row) => row?.r ?? row?.runs);
+    const bowlingRows = bowlingRowsForIntegrity(innings);
+    const bowlingRuns = sumNumeric(bowlingRows, (row) => row?.r ?? row?.runs);
+    const knownBowlingExtras = sumNumeric(bowlingRows, (row) => Number(row?.nb || 0) + Number(row?.wd || 0));
+    const extrasGap = topRuns - battingRuns;
+    const label = inningLabel(innings) || `innings ${index + 1}`;
+
+    if (battingRuns > topRuns) {
+      issues.push(`${label} batting rows total ${battingRuns} exceeds top-level total ${topRuns}`);
+    }
+    if (bowlingRuns > topRuns) {
+      issues.push(`${label} bowling rows total ${bowlingRuns} exceeds top-level total ${topRuns}`);
+    }
+    if (extrasGap >= 0 && knownBowlingExtras > extrasGap) {
+      issues.push(`${label} bowling extras ${knownBowlingExtras} exceed top-level extras gap ${extrasGap}`);
+    }
+    if (extrasGap > 40) {
+      issues.push(`${label} top-level total ${topRuns} is ${extrasGap} runs above batting rows total ${battingRuns}`);
+    }
+  });
 
   return issues;
 }

--- a/scripts/update-live-data.mjs
+++ b/scripts/update-live-data.mjs
@@ -623,6 +623,25 @@ function assertCompletedScorecardCacheable(matchId, scorecard) {
   throw error;
 }
 
+export function isIncompleteCompletedScorecardError(error) {
+  return String(error?.code || '') === 'CRICKETDATA_INCOMPLETE_SCORECARD';
+}
+
+export function incompleteCompletedScorecardDetails(error, fallbackMatchId = null) {
+  if (!isIncompleteCompletedScorecardError(error)) return null;
+  const integrityIssues = safeArray(error?.integrityIssues)
+    .map((issue) => String(issue || '').trim())
+    .filter(Boolean);
+  return {
+    reason: 'incomplete_completed_scorecard',
+    rawReason: integrityIssues.length
+      ? integrityIssues.join('; ')
+      : String(error?.message || 'completed scorecard failed integrity checks'),
+    matchId: String(error?.matchId || fallbackMatchId || '').trim() || null,
+    integrityIssues
+  };
+}
+
 export async function findMissingScorecardCaches(matchIds, { cacheDir = SCORECARD_CACHE_DIR } = {}) {
   const missing = [];
   for (const matchId of safeArray(matchIds)) {
@@ -703,6 +722,13 @@ export function parseCricketDataScorecardNotFoundDetails(error) {
 
 export function isCricketDataScorecardNotFoundError(error) {
   return Boolean(parseCricketDataScorecardNotFoundDetails(error));
+}
+
+function scorecardNotReadyDetails(error, fallbackMatchId = null) {
+  return (
+    parseCricketDataScorecardNotFoundDetails(error) ||
+    incompleteCompletedScorecardDetails(error, fallbackMatchId)
+  );
 }
 
 export function isCricketDataFallbackEligibleError(error) {
@@ -1692,8 +1718,8 @@ export async function buildMiniFantasyPlayerHistoriesFromProcessedMatches(proces
         applyScorecardToAggregates(matchAggregate, scorecardResult.data, { isFinal: true });
       }
     } catch (error) {
-      const missingScorecard = parseCricketDataScorecardNotFoundDetails(error);
-      if (!missingScorecard && !isMissingProcessedScorecardError(error)) throw error;
+      const notReadyScorecard = scorecardNotReadyDetails(error, processedRef?.id);
+      if (!notReadyScorecard && !isMissingProcessedScorecardError(error)) throw error;
     }
 
     if (!matchAggregate) {
@@ -1999,8 +2025,8 @@ export async function rebuildHistoricalState(processedIds, baseLive = null, { in
     try {
       scorecardResult = normalizeScorecardResult(await resolveScorecard(matchId));
     } catch (error) {
-      const missingScorecard = parseCricketDataScorecardNotFoundDetails(error);
-      if (!missingScorecard && !isMissingProcessedScorecardError(error)) throw error;
+      const notReadyScorecard = scorecardNotReadyDetails(error, matchId);
+      if (!notReadyScorecard && !isMissingProcessedScorecardError(error)) throw error;
       const fallbackOverlay = buildHistoricalAggregateOverlay(baseLive, processedMatchCount);
       if (!fallbackOverlay) throw error;
       rebuilt = combineAggregates(rebuilt, fallbackOverlay);
@@ -2082,9 +2108,9 @@ export async function repairScoreHistoryGaps(live, processedRefs, { loadScorecar
     try {
       scorecardResult = normalizeScorecardResult(await resolveScorecard(matchRef.id));
     } catch (error) {
-      const missingScorecard = parseCricketDataScorecardNotFoundDetails(error);
-      if (!missingScorecard) throw error;
-      noteDeferredScorecard(live, `score history gap ${count}`, matchRef.id, missingScorecard);
+      const notReadyScorecard = scorecardNotReadyDetails(error, matchRef.id);
+      if (!notReadyScorecard) throw error;
+      noteDeferredScorecard(live, `score history gap ${count}`, matchRef.id, notReadyScorecard);
       break;
     }
 
@@ -2464,11 +2490,11 @@ async function main() {
         live.meta.lastRun.historicalReplayUsedApiFallback = rebuiltState.apiCalls > 0;
         appliedHistoricalBackfill = true;
       } catch (error) {
-        const missingScorecard = parseCricketDataScorecardNotFoundDetails(error);
-        if (!missingScorecard) throw error;
+        const notReadyScorecard = scorecardNotReadyDetails(error);
+        if (!notReadyScorecard) throw error;
         live.meta.lastRun.historicalReplaySkipped = true;
-        live.meta.lastRun.historicalReplayReason = `historical replay deferred; ${missingScorecard.rawReason}`;
-        noteDeferredScorecard(live, 'historical replay', missingScorecard.matchId, missingScorecard);
+        live.meta.lastRun.historicalReplayReason = `historical replay deferred; ${notReadyScorecard.rawReason}`;
+        noteDeferredScorecard(live, 'historical replay', notReadyScorecard.matchId, notReadyScorecard);
       }
     }
   }
@@ -2487,11 +2513,11 @@ async function main() {
     }
     let scorecardResult;
     try {
-        scorecardResult = await processScorecard(match.id, live, { preferCache: true });
+      scorecardResult = await processScorecard(match.id, live, { preferCache: true });
     } catch (error) {
-      const missingScorecard = parseCricketDataScorecardNotFoundDetails(error);
-      if (!missingScorecard) throw error;
-      noteDeferredScorecard(live, 'backlog', match.id, missingScorecard);
+      const notReadyScorecard = scorecardNotReadyDetails(error, match.id);
+      if (!notReadyScorecard) throw error;
+      noteDeferredScorecard(live, 'backlog', match.id, notReadyScorecard);
       continue;
     }
     if (scorecardResult.source === 'cache') {
@@ -2551,9 +2577,9 @@ async function main() {
         live.meta.scorecardBudget.lastLiveScorecardAt = isoNow();
         live.meta.scorecardBudget.lastLiveScorecardMatchId = activeMatch.id;
       } catch (error) {
-        const missingScorecard = parseCricketDataScorecardNotFoundDetails(error);
-        if (!missingScorecard) throw error;
-        noteDeferredScorecard(live, 'live overlay', activeMatch.id, missingScorecard);
+        const notReadyScorecard = scorecardNotReadyDetails(error, activeMatch.id);
+        if (!notReadyScorecard) throw error;
+        noteDeferredScorecard(live, 'live overlay', activeMatch.id, notReadyScorecard);
         live.meta.lastRun.liveOverlaySkippedReason = 'scorecard not ready';
         overlayAgg = reusableOverlayAggregates(live, activeMatch);
         live.meta.lastRun.liveOverlayReused = !!overlayAgg;

--- a/tests/update-live-data.scorecard-cache.test.mjs
+++ b/tests/update-live-data.scorecard-cache.test.mjs
@@ -10,7 +10,9 @@ import {
   completedScorecardIntegrityIssues,
   findMissingScorecardCaches,
   freshScorecardBudgetRemaining,
+  incompleteCompletedScorecardDetails,
   inferProcessedMatchKeys,
+  isIncompleteCompletedScorecardError,
   matchKeyForMatch,
   readCachedScorecard,
   repairScoreHistoryGaps,
@@ -298,6 +300,21 @@ test('completed scorecard integrity check exempts no-result and abandoned matche
   assert.deepEqual(completedScorecardIntegrityIssues(abandoned), []);
 });
 
+test('incomplete completed scorecard errors are normalized as retryable not-ready scorecards', () => {
+  const error = new Error('Incomplete completed scorecard for match-31');
+  error.code = 'CRICKETDATA_INCOMPLETE_SCORECARD';
+  error.matchId = 'match-31';
+  error.integrityIssues = ['final score has 2 innings but scorecard has 1'];
+
+  assert.equal(isIncompleteCompletedScorecardError(error), true);
+  assert.deepEqual(incompleteCompletedScorecardDetails(error), {
+    reason: 'incomplete_completed_scorecard',
+    rawReason: 'final score has 2 innings but scorecard has 1',
+    matchId: 'match-31',
+    integrityIssues: ['final score has 2 innings but scorecard has 1']
+  });
+});
+
 test('historical rebuild tracks cache hits separately from paid API scorecard calls', async () => {
   const scorecards = {
     'match-1': makeFinalScorecard({
@@ -577,6 +594,75 @@ test('repairs missing score-history checkpoints from the nearest earlier snapsho
   assert.equal(repaired.cacheHits, 0);
   assert.deepEqual(repairedCounts, [0, 1, 2]);
   assert.equal(repairedSnapshot.snapshot.meta.aggregates.battingRuns['Virat Kohli'], 88);
+});
+
+test('defers incomplete completed scorecards during score-history gap repair', async () => {
+  const scorecards = {
+    'match-1': makeFinalScorecard({
+      teams: ['Punjab Kings', 'Delhi Capitals'],
+      winner: 'Punjab Kings',
+      batter: 'Prabhsimran Singh',
+      bowler: 'Kuldeep Yadav',
+      catcher: 'Shashank Singh',
+      runs: 61,
+      balls: 36,
+      sixes: 3,
+      wickets: 2,
+      concededRuns: 31,
+      overs: '4',
+      scoreA: 176,
+      scoreB: 161
+    })
+  };
+
+  const baseLive = {
+    mostDots: { ranking: [], extendedRanking: [], values: {} },
+    fairPlay: { winner: null, ranking: [], extendedRanking: [], values: {}, updatedAt: null, source: null },
+    meta: {
+      scoreHistory: [{ processedMatchCount: 0, fetchedAt: '2026-04-01T00:00:00.000Z' }]
+    }
+  };
+  const throughOneMatch = await rebuildHistoricalState(
+    ['match-1'],
+    baseLive,
+    {
+      includeHistory: true,
+      loadScorecard: async (matchId) => ({ data: scorecards[matchId], source: 'cache' })
+    }
+  );
+  const live = {
+    ...baseLive,
+    meta: {
+      lastRun: {},
+      scorecardBudget: {},
+      scoreHistory: throughOneMatch.scoreHistory
+    }
+  };
+  const incompleteError = new Error('Incomplete completed scorecard for match-2');
+  incompleteError.code = 'CRICKETDATA_INCOMPLETE_SCORECARD';
+  incompleteError.matchId = 'match-2';
+  incompleteError.integrityIssues = ['final score has 2 innings but scorecard has 1'];
+
+  const repaired = await repairScoreHistoryGaps(
+    live,
+    [
+      { id: 'match-1', matchKey: 'match:1' },
+      { id: 'match-2', matchKey: 'match:2' },
+      { id: 'match-3', matchKey: 'match:3' }
+    ],
+    {
+      loadScorecard: async (matchId) => {
+        if (matchId === 'match-2') throw incompleteError;
+        return { data: scorecards[matchId], source: 'cache' };
+      }
+    }
+  );
+
+  assert.equal(repaired.repaired, 0);
+  assert.equal(live.meta.lastRun.deferredScorecards, 1);
+  assert.deepEqual(live.meta.lastRun.deferredScorecardMatchIds, ['match-2']);
+  assert.match(live.meta.lastRun.deferredScorecardReason, /score history gap 2/);
+  assert.match(live.meta.lastRun.deferredScorecardReason, /final score has 2 innings but scorecard has 1/);
 });
 
 test('standings award one point each for no-result matches', async () => {

--- a/tests/update-live-data.scorecard-cache.test.mjs
+++ b/tests/update-live-data.scorecard-cache.test.mjs
@@ -167,19 +167,135 @@ test('completed scorecard integrity check catches final-score shells with partia
 
   assert.deepEqual(
     completedScorecardIntegrityIssues(partial),
-    ['final score has 2 innings but scorecard has 1']
+    [
+      'final score has 2 innings but scorecard has 1',
+      'Sunrisers Hyderabad Inning 1 top-level total 242 is 167 runs above batting rows total 75'
+    ]
   );
+});
+
+test('completed scorecard integrity check catches settled totals with stale batting rows', () => {
+  const staleTwoInnings = {
+    matchEnded: true,
+    status: 'Sunrisers Hyderabad won by 47 runs',
+    matchWinner: 'Sunrisers Hyderabad',
+    score: [
+      { inning: 'Sunrisers Hyderabad Inning 1', r: 242, w: 2, o: 20 },
+      { inning: 'Delhi Capitals Inning 1', r: 195, w: 9, o: 20 }
+    ],
+    scorecard: [
+      {
+        inning: 'Sunrisers Hyderabad Inning 1',
+        batting: [
+          { batsman: { name: 'Abhishek Sharma' }, r: 75 },
+          { batsman: { name: 'Travis Head' }, r: 37 },
+          { batsman: { name: 'Ishan Kishan' }, r: 22 }
+        ],
+        bowling: [
+          { bowler: { name: 'Mukesh Kumar' }, r: 20, nb: 0, wd: 1 },
+          { bowler: { name: 'Nitish Rana' }, r: 32, nb: 0, wd: 2 }
+        ]
+      },
+      {
+        inning: 'Delhi Capitals Inning 1',
+        batting: [
+          { batsman: { name: 'KL Rahul' }, r: 37 },
+          { batsman: { name: 'Nitish Rana' }, r: 57 }
+        ],
+        bowling: [
+          { bowler: { name: 'Eshan Malinga' }, r: 32, nb: 0, wd: 0 },
+          { bowler: { name: 'Sakib Hussain' }, r: 29, nb: 0, wd: 1 }
+        ]
+      }
+    ]
+  };
 
   assert.deepEqual(
-    completedScorecardIntegrityIssues({
-      ...partial,
-      scorecard: [
-        ...partial.scorecard,
-        { inning: 'Delhi Capitals Inning 1', batting: [{ batsman: { name: 'KL Rahul' }, r: 37 }] }
-      ]
-    }),
-    []
+    completedScorecardIntegrityIssues(staleTwoInnings),
+    [
+      'Sunrisers Hyderabad Inning 1 top-level total 242 is 108 runs above batting rows total 134',
+      'Delhi Capitals Inning 1 top-level total 195 is 101 runs above batting rows total 94'
+    ]
   );
+});
+
+test('completed scorecard integrity check accepts valid scorecards with byes or leg byes missing from provider extras', () => {
+  const completeWithUnlistedLegByes = {
+    matchEnded: true,
+    status: 'Rajasthan Royals won by 40 runs',
+    matchWinner: 'Rajasthan Royals',
+    score: [
+      { inning: 'Rajasthan Royals Inning 1', r: 159, w: 6, o: 20 },
+      { inning: 'Lucknow Super Giants Inning 1', r: 119, w: 10, o: 18 }
+    ],
+    scorecard: [
+      {
+        inning: 'Rajasthan Royals Inning 1',
+        batting: [
+          { batsman: { name: 'Yashasvi Jaiswal' }, r: 22 },
+          { batsman: { name: 'Vaibhav Sooryavanshi' }, r: 8 },
+          { batsman: { name: 'Dhruv Jurel' }, r: 0 },
+          { batsman: { name: 'Riyan Parag' }, r: 20 },
+          { batsman: { name: 'Shimron Hetmyer' }, r: 22 },
+          { batsman: { name: 'Ravindra Jadeja' }, r: 43 },
+          { batsman: { name: 'Donovan Ferreira' }, r: 20 },
+          { batsman: { name: 'Shubham Dubey' }, r: 19 }
+        ],
+        bowling: [
+          { bowler: { name: 'Mohammed Shami' }, r: 30, nb: 0, wd: 3 },
+          { bowler: { name: 'Prince Yadav' }, r: 29, nb: 0, wd: 0 },
+          { bowler: { name: 'Mohsin Khan' }, r: 17, nb: 0, wd: 0 },
+          { bowler: { name: 'Mayank Yadav' }, r: 56, nb: 0, wd: 1 },
+          { bowler: { name: 'Digvesh Singh Rathi' }, r: 26, nb: 0, wd: 0 }
+        ]
+      },
+      {
+        inning: 'Lucknow Super Giants Inning 1',
+        batting: [
+          { batsman: { name: 'Mitchell Marsh' }, r: 55 },
+          { batsman: { name: 'Ayush Badoni' }, r: 0 },
+          { batsman: { name: 'Rishabh Pant' }, r: 0 },
+          { batsman: { name: 'Aiden Markram' }, r: 0 },
+          { batsman: { name: 'Nicholas Pooran' }, r: 22 },
+          { batsman: { name: 'Himmat Singh' }, r: 15 },
+          { batsman: { name: 'Mukul Choudhary' }, r: 7 },
+          { batsman: { name: 'Mohammed Shami' }, r: 6 },
+          { batsman: { name: 'Mayank Yadav' }, r: 5 },
+          { batsman: { name: 'Digvesh Singh Rathi' }, r: 2 },
+          { batsman: { name: 'Mohsin Khan' }, r: 0 }
+        ],
+        bowling: [
+          { bowler: { name: 'Jofra Archer' }, r: 20, nb: 0, wd: 1 },
+          { bowler: { name: 'Nandre Burger' }, r: 27, nb: 0, wd: 0 },
+          { bowler: { name: 'Brijesh Sharma' }, r: 18, nb: 0, wd: 1 },
+          { bowler: { name: 'Ravindra Jadeja' }, r: 29, nb: 0, wd: 1 },
+          { bowler: { name: 'Ravi Bishnoi' }, r: 23, nb: 0, wd: 2 }
+        ]
+      }
+    ]
+  };
+
+  assert.deepEqual(completedScorecardIntegrityIssues(completeWithUnlistedLegByes), []);
+});
+
+test('completed scorecard integrity check exempts no-result and abandoned matches', () => {
+  const abandoned = {
+    matchEnded: true,
+    status: 'No result (rain)',
+    matchWinner: 'No Winner',
+    score: [
+      { inning: 'Kolkata Knight Riders Inning 1', r: 210, w: 4, o: 20 },
+      { inning: 'Punjab Kings Inning 1', r: 0, w: 0, o: 0 }
+    ],
+    scorecard: [
+      {
+        inning: 'Kolkata Knight Riders Inning 1',
+        batting: [{ batsman: { name: 'Rinku Singh' }, r: 12 }]
+      }
+    ]
+  };
+
+  assert.deepEqual(completedScorecardIntegrityIssues(abandoned), []);
 });
 
 test('historical rebuild tracks cache hits separately from paid API scorecard calls', async () => {


### PR DESCRIPTION
## Summary

Adds a stronger completed-scorecard integrity guard before fresh CricketData scorecards are cached.

The worker now rejects completed result scorecards when the nested player scorecard is materially inconsistent with the top-level innings totals, including cases where:

- the final top-level score has more innings than the nested scorecard,
- batting rows exceed the top-level innings total,
- bowling rows exceed the top-level innings total,
- known bowling extras exceed the top-level extras gap,
- the top-level innings total is far above the batting rows total, which catches stale partial scorecard rows under a final team score shell.

No-result, abandoned, and washout matches are exempt because partial scorecards can be legitimate there.

## Runtime behavior

If CricketData returns one of these stale completed scorecards, the refresh refuses to write it to `data/scorecards`. The run records the match as deferred, reuses existing historical/overlay data where available, and lets the next scheduled or manual run retry once the provider response settles.

## Why

CricketData can briefly return final team totals while the nested player scorecard is still stale. That is what caused Match 31 style scoring corruption. This guard prevents those partial completed scorecards from being cached and processed without turning normal provider-settling windows into hard workflow failures.

## Validation

- Current real Match 31 and Match 32 cached scorecards pass the new integrity check.
- Targeted scorecard-cache tests pass: 16/16.
- Full node suite passes: 101/101.