### PR TITLE
Dev

### DIFF
--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -1,14 +1,18 @@
 import {
   ENGINE_VERSION as PRICING_ENGINE_VERSION,
-  calculateEligiblePercentiles,
+  DEFAULT_MISSED_FIXTURE_PENALTIES,
+  DEFAULT_RANK_PRICE_BUCKETS,
+  assignRankBucketPrices,
+  clamp,
   computeAdjustedScore,
   computeLastMatchPoints,
+  computeMissedFixturePenalty,
   computeRecentAveragePoints,
   computeReliabilityFactor,
   computeScoreBasis,
   computeSeasonAveragePoints,
   generatePrices,
-  mapPercentileToPrice,
+  resolvePlayerPriceMax,
   roundTo
 } from './pricing-engine.js';
 
@@ -50,10 +54,17 @@ export const TEAM_NAME_TO_CODE = Object.freeze(
 );
 
 const DEFAULT_PRICE_JOB_META = Object.freeze({
-  price_min: 4,
+  price_min: 4.5,
   price_max: 10,
   recent_matches_window: 3,
-  max_daily_price_step: 1,
+  max_daily_price_step: 2,
+  price_increment: 0.5,
+  rank_price_buckets: DEFAULT_RANK_PRICE_BUCKETS,
+  smoothing: Object.freeze({
+    old_price_weight: 0.4,
+    target_price_weight: 0.6
+  }),
+  missed_fixture_penalties: DEFAULT_MISSED_FIXTURE_PENALTIES,
   default_initial_price: 6,
   scoring_source: 'existing_mvp_points_formula_v1',
   notes: 'Daily pricing refresh after all completed matches for the day'
@@ -827,6 +838,63 @@ export function deriveCompletedMatchHistories(liveData = {}, schedule = []) {
   return histories;
 }
 
+function getLatestCompletedMiniFantasyMatchNo(liveData = {}, historyMap = new Map()) {
+  const scoreHistory = Array.isArray(liveData?.meta?.scoreHistory) ? liveData.meta.scoreHistory : [];
+  const latestScoreHistoryMatchNo = scoreHistory.reduce(
+    (max, entry) => Math.max(max, Math.trunc(toNumber(entry?.processedMatchCount, 0))),
+    0
+  );
+  let latestHistoryMatchNo = 0;
+  if (historyMap instanceof Map) {
+    historyMap.forEach((history) => {
+      Object.keys(history?.points_by_match_no || {}).forEach((matchNo) => {
+        latestHistoryMatchNo = Math.max(latestHistoryMatchNo, Math.trunc(toNumber(matchNo, 0)));
+      });
+    });
+  }
+  return Math.max(latestScoreHistoryMatchNo, latestHistoryMatchNo, 0);
+}
+
+function buildTeamCompletedFixtureMap(schedule = [], latestCompletedMatchNo = 0) {
+  const teamFixtureMap = new Map();
+  (Array.isArray(schedule) ? schedule : []).forEach((fixture) => {
+    const matchNo = Math.trunc(toNumber(fixture?.match_no, 0));
+    if (matchNo <= 0 || matchNo > latestCompletedMatchNo) return;
+    const teamCodes = [
+      fixture?.home_team_code || resolveFixtureTeamCode(fixture?.home_team),
+      fixture?.away_team_code || resolveFixtureTeamCode(fixture?.away_team)
+    ].filter(Boolean);
+    teamCodes.forEach((teamCode) => {
+      if (!teamFixtureMap.has(teamCode)) {
+        teamFixtureMap.set(teamCode, []);
+      }
+      teamFixtureMap.get(teamCode).push(matchNo);
+    });
+  });
+
+  teamFixtureMap.forEach((matchNos) => {
+    matchNos.sort((left, right) => left - right);
+  });
+  return teamFixtureMap;
+}
+
+function calculateConsecutiveMissedFixtures(teamCode = '', history = {}, teamCompletedFixtureMap = new Map()) {
+  const completedFixtures = teamCompletedFixtureMap.get(teamCode) || [];
+  if (!completedFixtures.length) return 0;
+  const playedMatchNos = new Set(
+    Object.keys(history?.points_by_match_no || {})
+      .map((matchNo) => Math.trunc(toNumber(matchNo, 0)))
+      .filter((matchNo) => matchNo > 0)
+  );
+  let streak = 0;
+  for (let index = completedFixtures.length - 1; index >= 0; index -= 1) {
+    const matchNo = completedFixtures[index];
+    if (playedMatchNos.has(matchNo)) break;
+    streak += 1;
+  }
+  return streak;
+}
+
 export function seedInitialPriceMap(players = [], jobMeta = DEFAULT_PRICE_JOB_META) {
   const eligiblePlayers = (Array.isArray(players) ? players : [])
     .filter((player) => player.pricing_eligible)
@@ -836,20 +904,27 @@ export function seedInitialPriceMap(players = [], jobMeta = DEFAULT_PRICE_JOB_ME
       const scoreBasis = computeScoreBasis(recentAveragePoints, seasonAveragePoints);
       const reliabilityFactor = computeReliabilityFactor(player.matches_played || 0);
       const adjustedScore = computeAdjustedScore(scoreBasis, reliabilityFactor);
-      return {
-        player_id: player.player_id,
-        adjusted_score: adjustedScore
-      };
-    });
-  const percentiles = calculateEligiblePercentiles(eligiblePlayers);
+        return {
+          player_id: player.player_id,
+          adjusted_score: adjustedScore,
+          adjusted_score_raw: adjustedScore
+        };
+      });
+  const targetPrices = assignRankBucketPrices(eligiblePlayers, jobMeta.rank_price_buckets || DEFAULT_RANK_PRICE_BUCKETS);
   const seedMap = new Map();
   (Array.isArray(players) ? players : []).forEach((player) => {
-    if (!player.pricing_eligible || !Number(player.matches_played || 0)) {
+    if (!player.pricing_eligible) {
       seedMap.set(player.player_id, jobMeta.default_initial_price);
       return;
     }
-    const percentile = percentiles.get(player.player_id) ?? 0;
-    seedMap.set(player.player_id, mapPercentileToPrice(percentile));
+    const priceMax = resolvePlayerPriceMax(player, jobMeta.price_max);
+    const rawTargetPrice = targetPrices.get(player.player_id) ?? jobMeta.default_initial_price;
+    const penalizedTargetPrice = clamp(
+      rawTargetPrice - computeMissedFixturePenalty(player.missed_fixture_streak, jobMeta.missed_fixture_penalties),
+      jobMeta.price_min,
+      priceMax
+    );
+    seedMap.set(player.player_id, penalizedTargetPrice);
   });
   return seedMap;
 }
@@ -878,10 +953,12 @@ export function buildPricingJobFromLiveData({
     as_of_utc: asOfUtc,
     ...DEFAULT_PRICE_JOB_META,
     ...(jobMeta || {})
-  };
-  const roleLookup = buildTeamRoleLookup(teamRoles);
-  const previousPrices = buildPreviousPriceMap(previousPriceBook);
-  const historyMap = deriveCompletedMatchHistories(liveData, schedule);
+    };
+    const roleLookup = buildTeamRoleLookup(teamRoles);
+    const previousPrices = buildPreviousPriceMap(previousPriceBook);
+    const historyMap = deriveCompletedMatchHistories(liveData, schedule);
+    const latestCompletedMatchNo = getLatestCompletedMiniFantasyMatchNo(liveData, historyMap);
+    const teamCompletedFixtureMap = buildTeamCompletedFixtureMap(schedule, latestCompletedMatchNo);
 
   const players = [];
   Object.entries(squads || {}).forEach(([teamCode, squadPlayers]) => {
@@ -892,26 +969,29 @@ export function buildPricingJobFromLiveData({
         points_by_match_no: {},
         matches_played: 0,
         last_match_played_at_utc: null
-      };
-      const role = resolveRoleFromTeamMap(teamCode, playerName, roleLookup[teamCode] || {});
-      const playerId = buildMiniFantasyPlayerId(teamCode, playerName);
-      const previous = previousPrices.get(playerId);
-      players.push({
-        player_id: playerId,
-        name: playerName,
-        team: teamCode,
-        role: role || 'batter',
+        };
+        const role = resolveRoleFromTeamMap(teamCode, playerName, roleLookup[teamCode] || {});
+        const playerId = buildMiniFantasyPlayerId(teamCode, playerName);
+        const previous = previousPrices.get(playerId);
+        const missedFixtureStreak = calculateConsecutiveMissedFixtures(teamCode, history, teamCompletedFixtureMap);
+        players.push({
+          player_id: playerId,
+          name: playerName,
+          team: teamCode,
+          role: role || 'batter',
         is_uncapped: UNCAPPED_MVP_PLAYER_KEYS.has(canonicalName),
         pricing_eligible: Boolean(role),
-        old_price: Number.isFinite(previous?.final_price) ? previous.final_price : null,
-        initial_price: Number.isFinite(previous?.final_price) ? previous.final_price : null,
-        recovered_history: Number(previous?.matches_played || 0) === 0 && Number(history.matches_played || 0) > 0,
-        match_points: [...(history.match_points || [])],
-        matches_played: Number(history.matches_played || 0),
-        last_match_played_at_utc: history.last_match_played_at_utc || null
+          old_price: Number.isFinite(previous?.final_price) ? previous.final_price : null,
+          initial_price: Number.isFinite(previous?.final_price) ? previous.final_price : null,
+          recovered_history: Number(previous?.matches_played || 0) === 0 && Number(history.matches_played || 0) > 0,
+          match_points: [...(history.match_points || [])],
+          points_by_match_no: { ...(history.points_by_match_no || {}) },
+          matches_played: Number(history.matches_played || 0),
+          missed_fixture_streak: missedFixtureStreak,
+          last_match_played_at_utc: history.last_match_played_at_utc || null
+        });
       });
     });
-  });
 
   const seededInitialPrices = seedInitialPriceMap(players, effectiveMeta);
   players.forEach((player) => {

--- a/mini-fantasy/contest-engine.js
+++ b/mini-fantasy/contest-engine.js
@@ -855,11 +855,23 @@ function getLatestCompletedMiniFantasyMatchNo(liveData = {}, historyMap = new Ma
   return Math.max(latestScoreHistoryMatchNo, latestHistoryMatchNo, 0);
 }
 
-function buildTeamCompletedFixtureMap(schedule = [], latestCompletedMatchNo = 0) {
+function buildMiniFantasyNoResultMatchSet(liveData = {}) {
+  const noResultMatchNos = new Set();
+  cachedMiniFantasyMatchList(liveData).forEach((match) => {
+    const matchNo = Math.trunc(toNumber(match?.matchNo, 0));
+    if (matchNo > 0 && isMiniFantasyNoResultStatus(match?.status || '')) {
+      noResultMatchNos.add(matchNo);
+    }
+  });
+  return noResultMatchNos;
+}
+
+function buildTeamCompletedFixtureMap(schedule = [], latestCompletedMatchNo = 0, liveData = {}) {
   const teamFixtureMap = new Map();
+  const noResultMatchNos = buildMiniFantasyNoResultMatchSet(liveData);
   (Array.isArray(schedule) ? schedule : []).forEach((fixture) => {
     const matchNo = Math.trunc(toNumber(fixture?.match_no, 0));
-    if (matchNo <= 0 || matchNo > latestCompletedMatchNo) return;
+    if (matchNo <= 0 || matchNo > latestCompletedMatchNo || noResultMatchNos.has(matchNo)) return;
     const teamCodes = [
       fixture?.home_team_code || resolveFixtureTeamCode(fixture?.home_team),
       fixture?.away_team_code || resolveFixtureTeamCode(fixture?.away_team)
@@ -958,7 +970,7 @@ export function buildPricingJobFromLiveData({
     const previousPrices = buildPreviousPriceMap(previousPriceBook);
     const historyMap = deriveCompletedMatchHistories(liveData, schedule);
     const latestCompletedMatchNo = getLatestCompletedMiniFantasyMatchNo(liveData, historyMap);
-    const teamCompletedFixtureMap = buildTeamCompletedFixtureMap(schedule, latestCompletedMatchNo);
+    const teamCompletedFixtureMap = buildTeamCompletedFixtureMap(schedule, latestCompletedMatchNo, liveData);
 
   const players = [];
   Object.entries(squads || {}).forEach(([teamCode, squadPlayers]) => {

--- a/mini-fantasy/pricing-engine.js
+++ b/mini-fantasy/pricing-engine.js
@@ -264,7 +264,8 @@ export function assignRankBucketPrices(players, buckets = DEFAULT_RANK_PRICE_BUC
 export function computeMissedFixturePenalty(missedFixtureStreak, penalties = DEFAULT_MISSED_FIXTURE_PENALTIES) {
   const normalizedStreak = Number.isFinite(missedFixtureStreak) ? Math.max(0, Math.trunc(missedFixtureStreak)) : 0;
   const matchingPenalty = (Array.isArray(penalties) ? penalties : [])
-    .find((rule) => normalizedStreak >= Number(rule?.minimum_streak || 0));
+    .filter((rule) => normalizedStreak >= Number(rule?.minimum_streak || 0))
+    .sort((left, right) => Number(right?.minimum_streak || 0) - Number(left?.minimum_streak || 0))[0];
   return matchingPenalty ? Number(matchingPenalty.penalty || 0) : 0;
 }
 

--- a/mini-fantasy/pricing-engine.js
+++ b/mini-fantasy/pricing-engine.js
@@ -1,12 +1,18 @@
-const RECENT_AVERAGE_WEIGHT = 0.6;
-const SEASON_AVERAGE_WEIGHT = 0.4;
-const BASE_PRICE_WEIGHT = 0.7;
-const TARGET_PRICE_WEIGHT = 0.3;
-const FULL_CONFIDENCE_MATCHES = 4;
+const RECENT_AVERAGE_WEIGHT = 2 / 3;
+const SEASON_AVERAGE_WEIGHT = 1 / 3;
+const BASE_PRICE_WEIGHT = 0.4;
+const TARGET_PRICE_WEIGHT = 0.6;
+const FULL_CONFIDENCE_MATCHES = 2;
 const TIE_EPSILON = 1e-9;
-export const UNCAPPED_PLAYER_PRICE_MAX = 9;
+const PRICE_INCREMENT = 0.5;
+export const UNCAPPED_PLAYER_PRICE_MAX = 9.5;
+export const DEFAULT_MISSED_FIXTURE_PENALTIES = Object.freeze([
+  { minimum_streak: 4, penalty: 1.5 },
+  { minimum_streak: 3, penalty: 1 },
+  { minimum_streak: 2, penalty: 0.5 }
+]);
 
-export const ENGINE_VERSION = 'pricing_v1';
+export const ENGINE_VERSION = 'pricing_v2';
 
 export const DEFAULT_PERCENTILE_PRICE_BANDS = Object.freeze([
   { gt: 0, lte: 10, price: 4 },
@@ -18,14 +24,29 @@ export const DEFAULT_PERCENTILE_PRICE_BANDS = Object.freeze([
   { gt: 92, lte: 100, price: 10 }
 ]);
 
+export const DEFAULT_RANK_PRICE_BUCKETS = Object.freeze([
+  { price: 10, slots: 5 },
+  { price: 9.5, slots: 8 },
+  { price: 9, slots: 14 },
+  { price: 8.5, slots: 20 },
+  { price: 8, slots: 28 },
+  { price: 7.5, slots: 36 },
+  { price: 7, slots: 42 },
+  { price: 6.5, slots: 38 },
+  { price: 6, slots: 28 },
+  { price: 5.5, slots: 18 },
+  { price: 5, slots: 11 },
+  { price: 4.5, slots: 6 }
+]);
+
 export const PRICING_ENGINE_CONFIG_V1 = Object.freeze({
   engine_version: ENGINE_VERSION,
   rules: {
-    price_min: 4,
+    price_min: 4.5,
     price_max: 10,
     uncapped_price_max: UNCAPPED_PLAYER_PRICE_MAX,
     recent_matches_window: 3,
-    max_daily_price_step: 1,
+    max_daily_price_step: 2,
     default_initial_price: 6,
     score_basis_weights: {
       recent_avg_points: RECENT_AVERAGE_WEIGHT,
@@ -38,11 +59,13 @@ export const PRICING_ENGINE_CONFIG_V1 = Object.freeze({
     smoothing: {
       old_price_weight: BASE_PRICE_WEIGHT,
       target_price_weight: TARGET_PRICE_WEIGHT,
-      rounding: 'nearest_integer'
+      rounding: 'nearest_half_step_with_downward_floor_on_price_drop'
     },
     percentile_price_bands: DEFAULT_PERCENTILE_PRICE_BANDS,
+    rank_price_buckets: DEFAULT_RANK_PRICE_BUCKETS,
+    missed_fixture_penalties: DEFAULT_MISSED_FIXTURE_PENALTIES,
     special_cases: {
-      no_matches_played: 'retain_base_price',
+      no_matches_played: 'rank_and_smooth',
       not_pricing_eligible: 'retain_base_price',
       missing_old_price: 'fallback_to_initial_or_default'
     }
@@ -56,6 +79,18 @@ export function clamp(value, minimum, maximum) {
 export function roundTo(value, decimals = 2) {
   const factor = 10 ** decimals;
   return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function roundToPriceIncrement(value, increment = PRICE_INCREMENT, mode = 'nearest') {
+  const normalizedIncrement = Number.isFinite(increment) && increment > 0 ? increment : PRICE_INCREMENT;
+  const scaled = value / normalizedIncrement;
+  const roundedScaled =
+    mode === 'down'
+      ? Math.floor(scaled + Number.EPSILON)
+      : mode === 'up'
+      ? Math.ceil(scaled - Number.EPSILON)
+      : Math.round(scaled);
+  return roundTo(roundedScaled * normalizedIncrement, 2);
 }
 
 export function average(values) {
@@ -122,20 +157,20 @@ export function computeAdjustedScore(scoreBasis, reliabilityFactor) {
 export function resolveBasePrice(player, defaultInitialPrice) {
   if (Number.isFinite(player.old_price)) {
     return {
-      basePrice: Math.round(player.old_price),
+      basePrice: roundToPriceIncrement(player.old_price),
       note: 'Used old_price for smoothing'
     };
   }
 
   if (Number.isFinite(player.initial_price)) {
     return {
-      basePrice: Math.round(player.initial_price),
+      basePrice: roundToPriceIncrement(player.initial_price),
       note: 'Missing old_price; used initial_price as base'
     };
   }
 
   return {
-    basePrice: Math.round(defaultInitialPrice),
+    basePrice: roundToPriceIncrement(defaultInitialPrice),
     note: 'Missing old_price and initial_price; used default initial price'
   };
 }
@@ -153,8 +188,93 @@ export function mapPercentileToPrice(percentile, bands = DEFAULT_PERCENTILE_PRIC
   return matchingBand ? matchingBand.price : bands[bands.length - 1].price;
 }
 
-export function smoothPrice(basePrice, targetPrice) {
-  return Math.round(BASE_PRICE_WEIGHT * basePrice + TARGET_PRICE_WEIGHT * targetPrice);
+export function allocateRankBucketCounts(totalPlayers, buckets = DEFAULT_RANK_PRICE_BUCKETS) {
+  if (!Number.isFinite(totalPlayers) || totalPlayers <= 0) {
+    return [];
+  }
+
+  const normalizedBuckets = Array.isArray(buckets)
+    ? buckets
+        .map((bucket, index) => ({
+          index,
+          price: Number(bucket?.price),
+          slots: Number(bucket?.slots)
+        }))
+        .filter((bucket) => Number.isFinite(bucket.price) && Number.isFinite(bucket.slots) && bucket.slots > 0)
+    : [];
+
+  if (!normalizedBuckets.length) {
+    return [];
+  }
+
+  const totalSlots = normalizedBuckets.reduce((sum, bucket) => sum + bucket.slots, 0);
+  const provisional = normalizedBuckets.map((bucket) => {
+    const rawCount = (bucket.slots / totalSlots) * totalPlayers;
+    const floorCount = Math.floor(rawCount);
+    return {
+      ...bucket,
+      rawCount,
+      count: floorCount,
+      remainder: rawCount - floorCount
+    };
+  });
+
+  let remaining = totalPlayers - provisional.reduce((sum, bucket) => sum + bucket.count, 0);
+  provisional
+    .slice()
+    .sort((left, right) => {
+      if (Math.abs(right.remainder - left.remainder) > TIE_EPSILON) {
+        return right.remainder - left.remainder;
+      }
+      return left.index - right.index;
+    })
+    .forEach((bucket) => {
+      if (remaining <= 0) return;
+      provisional[bucket.index].count += 1;
+      remaining -= 1;
+    });
+
+  return provisional.map(({ price, count }) => ({ price, count })).filter((bucket) => bucket.count > 0);
+}
+
+export function assignRankBucketPrices(players, buckets = DEFAULT_RANK_PRICE_BUCKETS) {
+  const rankingPool = Array.isArray(players)
+    ? players
+        .map((player) => ({
+          player_id: player.player_id,
+          adjusted_score: roundTo(player.adjusted_score_raw ?? player.adjusted_score ?? 0, 6)
+        }))
+        .sort((left, right) => {
+          if (Math.abs(right.adjusted_score - left.adjusted_score) > TIE_EPSILON) {
+            return right.adjusted_score - left.adjusted_score;
+          }
+          return left.player_id.localeCompare(right.player_id);
+        })
+    : [];
+
+  const allocatedBuckets = allocateRankBucketCounts(rankingPool.length, buckets);
+  const priceSequence = allocatedBuckets.flatMap((bucket) => Array.from({ length: bucket.count }, () => bucket.price));
+  const assignedPrices = new Map();
+  rankingPool.forEach((player, index) => {
+    assignedPrices.set(player.player_id, priceSequence[index] ?? allocatedBuckets[allocatedBuckets.length - 1]?.price ?? PRICING_ENGINE_CONFIG_V1.rules.price_min);
+  });
+  return assignedPrices;
+}
+
+export function computeMissedFixturePenalty(missedFixtureStreak, penalties = DEFAULT_MISSED_FIXTURE_PENALTIES) {
+  const normalizedStreak = Number.isFinite(missedFixtureStreak) ? Math.max(0, Math.trunc(missedFixtureStreak)) : 0;
+  const matchingPenalty = (Array.isArray(penalties) ? penalties : [])
+    .find((rule) => normalizedStreak >= Number(rule?.minimum_streak || 0));
+  return matchingPenalty ? Number(matchingPenalty.penalty || 0) : 0;
+}
+
+export function smoothPrice(basePrice, targetPrice, options = {}) {
+  const oldPriceWeight = Number.isFinite(options.old_price_weight) ? options.old_price_weight : BASE_PRICE_WEIGHT;
+  const targetPriceWeight = Number.isFinite(options.target_price_weight) ? options.target_price_weight : TARGET_PRICE_WEIGHT;
+  const increment = Number.isFinite(options.increment) ? options.increment : PRICE_INCREMENT;
+  const weightedPrice = oldPriceWeight * basePrice + targetPriceWeight * targetPrice;
+  const roundingMode = targetPrice < basePrice ? 'down' : 'nearest';
+  return roundToPriceIncrement(weightedPrice, increment, roundingMode);
 }
 
 export function capPriceMovement(candidatePrice, basePrice, maxDailyStep, priceMin, priceMax) {
@@ -245,17 +365,16 @@ function createCalculationNotes(player, derived, targetPrice, smoothedPrice, fin
     return notes;
   }
 
-  if (derived.effectiveMatchesPlayed === 0) {
-    notes.push('No matches played; retained base price');
-    return notes;
-  }
-
   if (derived.recoveredHistory) {
     notes.push('Recovered real match history from a previously blank price; used the corrected target price immediately');
   }
 
   if (targetPrice !== derived.basePrice) {
-    notes.push(`Target price mapped from percentile ${roundTo(derived.percentile, 2)}`);
+    notes.push(`Target price assigned from rank bucket at rank ${derived.rank}`);
+  }
+
+  if (derived.missedFixturePenalty > 0) {
+    notes.push(`Applied ${derived.missedFixturePenalty}-credit missed-fixture penalty after ${derived.missedFixtureStreak} consecutive misses`);
   }
 
   if (smoothedPrice !== targetPrice) {
@@ -294,6 +413,7 @@ function derivePlayerInputs(player, jobMeta) {
     basePrice,
     maxDailyPriceStep: jobMeta.max_daily_price_step,
     recoveredHistory: Boolean(player.recovered_history) && effectiveMatchesPlayed > 0,
+    missedFixtureStreak: Number.isFinite(player.missed_fixture_streak) ? Math.max(0, Math.trunc(player.missed_fixture_streak)) : 0,
     matchPoints,
     seasonAveragePoints,
     recentAveragePoints,
@@ -317,29 +437,51 @@ export function generatePrices(input) {
       adjusted_score_raw: entry.adjustedScoreRaw
     }));
   const percentiles = calculateEligiblePercentiles(eligibleRankingPool);
+  const rankBucketPrices = assignRankBucketPrices(
+    eligibleRankingPool,
+    input.job_meta.rank_price_buckets || DEFAULT_RANK_PRICE_BUCKETS
+  );
+  const rankByPlayerId = new Map();
+  let rankCounter = 1;
+  rankBucketPrices.forEach((_price, playerId) => {
+    rankByPlayerId.set(playerId, rankCounter);
+    rankCounter += 1;
+  });
 
   const players = derivedPlayers
     .map((entry) => {
       const playerPriceMax = resolvePlayerPriceMax(entry.player, input.job_meta.price_max);
       const percentile = entry.player.pricing_eligible ? percentiles.get(entry.player.player_id) ?? 0 : 0;
+      const rank = entry.player.pricing_eligible
+        ? rankByPlayerId.get(entry.player.player_id) ?? 0
+        : 0;
       const rawTargetPrice = entry.player.pricing_eligible
-        ? mapPercentileToPrice(percentile)
+        ? rankBucketPrices.get(entry.player.player_id) ?? entry.basePrice
         : entry.basePrice;
-      const targetPrice = clamp(rawTargetPrice, input.job_meta.price_min, playerPriceMax);
+        const missedFixturePenalty = entry.player.pricing_eligible
+          ? computeMissedFixturePenalty(
+              entry.missedFixtureStreak,
+              input.job_meta.missed_fixture_penalties || DEFAULT_MISSED_FIXTURE_PENALTIES
+            )
+          : 0;
+      const targetPrice = clamp(rawTargetPrice - missedFixturePenalty, input.job_meta.price_min, playerPriceMax);
 
-      // Keep brand-new or inactive players stable until they have usable ranked history.
       const rawSmoothedPrice =
         entry.recoveredHistory
           ? targetPrice
-          : entry.player.pricing_eligible && entry.effectiveMatchesPlayed > 0
-          ? smoothPrice(entry.basePrice, targetPrice)
+          : entry.player.pricing_eligible
+          ? smoothPrice(entry.basePrice, targetPrice, {
+              old_price_weight: input.job_meta.smoothing?.old_price_weight ?? BASE_PRICE_WEIGHT,
+              target_price_weight: input.job_meta.smoothing?.target_price_weight ?? TARGET_PRICE_WEIGHT,
+              increment: input.job_meta.price_increment ?? PRICE_INCREMENT
+            })
           : entry.basePrice;
       const smoothedPrice = clamp(rawSmoothedPrice, input.job_meta.price_min, playerPriceMax);
 
       const finalPrice =
         entry.recoveredHistory
           ? clamp(targetPrice, input.job_meta.price_min, playerPriceMax)
-          : entry.player.pricing_eligible && entry.effectiveMatchesPlayed > 0
+          : entry.player.pricing_eligible
           ? capPriceMovement(
               smoothedPrice,
               entry.basePrice,
@@ -349,13 +491,27 @@ export function generatePrices(input) {
             )
           : clamp(entry.basePrice, input.job_meta.price_min, playerPriceMax);
 
-      const priceChange = entry.player.old_price == null ? 0 : finalPrice - Math.round(entry.player.old_price);
+      const priceChange = entry.player.old_price == null
+        ? 0
+        : roundTo(finalPrice - roundToPriceIncrement(entry.player.old_price, input.job_meta.price_increment ?? PRICE_INCREMENT), 2);
       const uncappedCapApplied = Boolean(entry.player.is_uncapped) && (
         rawTargetPrice > playerPriceMax ||
         rawSmoothedPrice > playerPriceMax ||
         entry.basePrice > playerPriceMax
       );
-      const calculationNotes = createCalculationNotes(entry.player, { ...entry, percentile }, targetPrice, smoothedPrice, finalPrice, uncappedCapApplied);
+      const calculationNotes = createCalculationNotes(
+        entry.player,
+        {
+          ...entry,
+          percentile,
+          rank,
+          missedFixturePenalty
+        },
+        targetPrice,
+        smoothedPrice,
+        finalPrice,
+        uncappedCapApplied
+      );
 
       return {
         player_id: entry.player.player_id,
@@ -379,6 +535,8 @@ export function generatePrices(input) {
         reliability_factor: entry.reliabilityFactor,
         adjusted_score: entry.adjustedScore,
         percentile,
+        rank,
+        missed_fixture_streak: entry.missedFixtureStreak,
         calculation_notes: calculationNotes,
         last_match_played_at_utc: entry.player.last_match_played_at_utc
       };

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -1083,6 +1083,85 @@ test('generateMiniFantasyPriceBook penalizes players who keep missing team fixtu
   assert.match(missedBench.calculation_notes.join(' '), /missed-fixture penalty/i);
 });
 
+test('generateMiniFantasyPriceBook skips no-result fixtures when counting missed streaks', () => {
+  const liveData = {
+    fetchedAt: '2026-04-10T00:10:00Z',
+    meta: {
+      cache: {
+        matchList: [
+          {
+            matchNo: 15,
+            status: 'No result (due to rain)',
+            teams: ['Kolkata Knight Riders', 'Delhi Capitals']
+          }
+        ]
+      },
+      scoreHistory: [
+        {
+          processedMatchCount: 14,
+          snapshot: {
+            meta: { aggregates: { playerMatches: { 'Active Star': 1 } } },
+            mvp: { values: { 'Active Star': { score: 50 } } }
+          }
+        },
+        {
+          processedMatchCount: 15,
+          snapshot: {
+            meta: { aggregates: { playerMatches: { 'Active Star': 1 } } },
+            mvp: { values: { 'Active Star': { score: 50 } } }
+          }
+        },
+        {
+          processedMatchCount: 16,
+          snapshot: {
+            meta: { aggregates: { playerMatches: { 'Active Star': 2 } } },
+            mvp: { values: { 'Active Star': { score: 105 } } }
+          }
+        }
+      ]
+    }
+  };
+  const schedule = [
+    { match_no: 14, datetime_utc: '2026-04-08T14:00:00Z', home_team: 'Kolkata Knight Riders', away_team: 'Mumbai Indians' },
+    { match_no: 15, datetime_utc: '2026-04-09T14:00:00Z', home_team: 'Kolkata Knight Riders', away_team: 'Delhi Capitals' },
+    { match_no: 16, datetime_utc: '2026-04-10T14:00:00Z', home_team: 'Lucknow Super Giants', away_team: 'Kolkata Knight Riders' }
+  ];
+  const squads = {
+    KKR: ['Active Star', 'Missed Bench']
+  };
+  const teamRoles = {
+    teams: {
+      KKR: {
+        players: {
+          'Active Star': 'batter',
+          'Missed Bench': 'batter'
+        }
+      }
+    }
+  };
+
+  const priceBook = generateMiniFantasyPriceBook({
+    liveData,
+    schedule,
+    squads,
+    teamRoles,
+    asOfUtc: '2026-04-10T00:10:00Z',
+    jobMeta: {
+      rank_price_buckets: [
+        { price: 10, slots: 1 },
+        { price: 6, slots: 1 }
+      ]
+    }
+  });
+
+  const missedBench = priceBook.players.find((player) => player.player_id === buildMiniFantasyPlayerId('KKR', 'Missed Bench'));
+  assert.equal(missedBench.matches_played, 0);
+  assert.equal(missedBench.missed_fixture_streak, 2);
+  assert.equal(missedBench.target_price, 5.5);
+  assert.equal(missedBench.final_price, 5.5);
+  assert.match(missedBench.calculation_notes.join(' '), /missed-fixture penalty/i);
+});
+
 test('generateMiniFantasyPriceBook keeps alias-matched LSG bowlers from falling back to blank stats', () => {
   const liveData = {
     fetchedAt: '2026-04-08T00:10:00Z',

--- a/tests/mini-fantasy-contest-engine.test.mjs
+++ b/tests/mini-fantasy-contest-engine.test.mjs
@@ -952,7 +952,7 @@ test('generateMiniFantasyPriceBook matches Lhuan-dre Pretorious against Pretoriu
   assert.equal(pretorious.last_match_points, 45);
 });
 
-test('generateMiniFantasyPriceBook marks uncapped players and caps them at 9 credits', () => {
+test('generateMiniFantasyPriceBook marks uncapped players and caps them at 9.5 credits', () => {
   const liveData = {
     fetchedAt: '2026-04-08T00:10:00Z',
     meta: {
@@ -998,13 +998,89 @@ test('generateMiniFantasyPriceBook marks uncapped players and caps them at 9 cre
     schedule,
     squads,
     teamRoles,
-    asOfUtc: '2026-04-08T00:10:00Z'
+    asOfUtc: '2026-04-08T00:10:00Z',
+    jobMeta: {
+      rank_price_buckets: [
+        { price: 10, slots: 1 },
+        { price: 9.5, slots: 1 }
+      ]
+    }
   });
 
   const sameer = priceBook.players.find((player) => player.player_id === buildMiniFantasyPlayerId('DC', 'Sameer Rizvi'));
   assert.equal(sameer.is_uncapped, true);
-  assert.equal(sameer.final_price, 9);
-  assert.match(sameer.calculation_notes.join(' '), /uncapped player price ceiling applied at 9 credits/i);
+  assert.equal(sameer.final_price, 9.5);
+  assert.match(sameer.calculation_notes.join(' '), /uncapped player price ceiling applied at 9.5 credits/i);
+});
+
+test('generateMiniFantasyPriceBook penalizes players who keep missing team fixtures', () => {
+  const liveData = {
+    fetchedAt: '2026-04-10T00:10:00Z',
+    meta: {
+      scoreHistory: [
+        {
+          processedMatchCount: 14,
+          snapshot: {
+            meta: { aggregates: { playerMatches: { 'Active Star': 1 } } },
+            mvp: { values: { 'Active Star': { score: 50 } } }
+          }
+        },
+        {
+          processedMatchCount: 15,
+          snapshot: {
+            meta: { aggregates: { playerMatches: { 'Active Star': 2 } } },
+            mvp: { values: { 'Active Star': { score: 105 } } }
+          }
+        },
+        {
+          processedMatchCount: 16,
+          snapshot: {
+            meta: { aggregates: { playerMatches: { 'Active Star': 3 } } },
+            mvp: { values: { 'Active Star': { score: 150 } } }
+          }
+        }
+      ]
+    }
+  };
+  const schedule = [
+    { match_no: 14, datetime_utc: '2026-04-08T14:00:00Z', home_team: 'Kolkata Knight Riders', away_team: 'Mumbai Indians' },
+    { match_no: 15, datetime_utc: '2026-04-09T14:00:00Z', home_team: 'Kolkata Knight Riders', away_team: 'Delhi Capitals' },
+    { match_no: 16, datetime_utc: '2026-04-10T14:00:00Z', home_team: 'Lucknow Super Giants', away_team: 'Kolkata Knight Riders' }
+  ];
+  const squads = {
+    KKR: ['Active Star', 'Missed Bench']
+  };
+  const teamRoles = {
+    teams: {
+      KKR: {
+        players: {
+          'Active Star': 'batter',
+          'Missed Bench': 'batter'
+        }
+      }
+    }
+  };
+
+  const priceBook = generateMiniFantasyPriceBook({
+    liveData,
+    schedule,
+    squads,
+    teamRoles,
+    asOfUtc: '2026-04-10T00:10:00Z',
+    jobMeta: {
+      rank_price_buckets: [
+        { price: 10, slots: 1 },
+        { price: 5, slots: 1 }
+      ]
+    }
+  });
+
+  const missedBench = priceBook.players.find((player) => player.player_id === buildMiniFantasyPlayerId('KKR', 'Missed Bench'));
+  assert.equal(missedBench.matches_played, 0);
+  assert.equal(missedBench.missed_fixture_streak, 3);
+  assert.equal(missedBench.target_price, 4.5);
+  assert.equal(missedBench.final_price, 4.5);
+  assert.match(missedBench.calculation_notes.join(' '), /missed-fixture penalty/i);
 });
 
 test('generateMiniFantasyPriceBook keeps alias-matched LSG bowlers from falling back to blank stats', () => {

--- a/tests/mini-fantasy-pricing-engine.test.mjs
+++ b/tests/mini-fantasy-pricing-engine.test.mjs
@@ -5,26 +5,35 @@ import path from 'node:path';
 
 import {
   average,
+  assignRankBucketPrices,
   calculateEligiblePercentiles,
   capPriceMovement,
+  computeMissedFixturePenalty,
   computeRecentAveragePoints,
   computeReliabilityFactor,
   generatePrices,
   mapPercentileToPrice,
+  roundToPriceIncrement,
   smoothPrice
 } from '../mini-fantasy/pricing-engine.js';
 
-function createJob(players) {
+function createJob(players, overrides = {}) {
   return {
     job_meta: {
       season: 'IPL 2026',
       as_of_utc: '2026-04-06T23:59:59Z',
-      price_min: 4,
+      price_min: 4.5,
       price_max: 10,
       recent_matches_window: 3,
-      max_daily_price_step: 1,
+      max_daily_price_step: 2,
+      price_increment: 0.5,
+      smoothing: {
+        old_price_weight: 0.4,
+        target_price_weight: 0.6
+      },
       default_initial_price: 6,
-      scoring_source: 'existing_mvp_points_formula_v1'
+      scoring_source: 'existing_mvp_points_formula_v1',
+      ...overrides
     },
     players
   };
@@ -33,16 +42,22 @@ function createJob(players) {
 test('helper functions stay deterministic around averages, reliability, smoothing, and caps', () => {
   assert.equal(average([]), 0);
   assert.equal(computeRecentAveragePoints([10, 20, 30, 40], 3), 30);
-  assert.equal(computeReliabilityFactor(1), 0.25);
+  assert.equal(computeReliabilityFactor(1), 0.5);
   assert.equal(computeReliabilityFactor(5), 1);
   assert.equal(mapPercentileToPrice(0), 4);
   assert.equal(mapPercentileToPrice(10), 4);
   assert.equal(mapPercentileToPrice(10.01), 5);
   assert.equal(mapPercentileToPrice(92), 9);
   assert.equal(mapPercentileToPrice(99), 10);
+  assert.equal(roundToPriceIncrement(9.74), 9.5);
+  assert.equal(roundToPriceIncrement(9.99, 0.5, 'down'), 9.5);
+  assert.equal(computeMissedFixturePenalty(1), 0);
+  assert.equal(computeMissedFixturePenalty(2), 0.5);
+  assert.equal(computeMissedFixturePenalty(4), 1.5);
   assert.equal(smoothPrice(8, 10), 9);
-  assert.equal(capPriceMovement(10, 8, 1, 4, 10), 9);
-  assert.equal(capPriceMovement(3, 5, 1, 4, 10), 4);
+  assert.equal(smoothPrice(10, 9.5), 9.5);
+  assert.equal(capPriceMovement(10, 8, 2, 4.5, 10), 10);
+  assert.equal(capPriceMovement(3, 5, 2, 4.5, 10), 4.5);
 });
 
 test('eligible percentile calculation gives ties the same percentile', () => {
@@ -55,6 +70,27 @@ test('eligible percentile calculation gives ties the same percentile', () => {
   assert.equal(percentiles.get('a'), 75);
   assert.equal(percentiles.get('b'), 75);
   assert.equal(percentiles.get('c'), 0);
+});
+
+test('assignRankBucketPrices follows exact bucket counts by sorted rank', () => {
+  const assigned = assignRankBucketPrices(
+    [
+      { player_id: 'a', adjusted_score: 90, adjusted_score_raw: 90 },
+      { player_id: 'b', adjusted_score: 80, adjusted_score_raw: 80 },
+      { player_id: 'c', adjusted_score: 70, adjusted_score_raw: 70 },
+      { player_id: 'd', adjusted_score: 60, adjusted_score_raw: 60 }
+    ],
+    [
+      { price: 10, slots: 1 },
+      { price: 9.5, slots: 1 },
+      { price: 7.5, slots: 2 }
+    ]
+  );
+
+  assert.equal(assigned.get('a'), 10);
+  assert.equal(assigned.get('b'), 9.5);
+  assert.equal(assigned.get('c'), 7.5);
+  assert.equal(assigned.get('d'), 7.5);
 });
 
 test('generatePrices applies ranking, smoothing, capping, inactive handling, and sorting', () => {
@@ -132,24 +168,32 @@ test('generatePrices applies ranking, smoothing, capping, inactive handling, and
         matches_played: 2,
         last_match_played_at_utc: '2026-04-03T18:30:00Z'
       }
-    ])
+    ], {
+      rank_price_buckets: [
+        { price: 10, slots: 1 },
+        { price: 8, slots: 1 },
+        { price: 7.5, slots: 1 },
+        { price: 6.5, slots: 1 },
+        { price: 6, slots: 1 }
+      ]
+    })
   );
 
   assert.deepEqual(output.summary, {
     total_players_received: 6,
     eligible_players_ranked: 5,
-    price_rises: 2,
+    price_rises: 4,
     price_drops: 0,
-    price_unchanged: 4
+    price_unchanged: 2
   });
 
   assert.deepEqual(
     output.players.map((player) => `${player.team}:${player.name}:${player.final_price}`),
     [
       'AAA:Alpha Star:9',
-      'AAA:Alpha Fringe:6',
-      'BBB:Beta Reliable:7',
-      'CCC:Gamma Mismatch:6',
+      'AAA:Alpha Fringe:7',
+      'BBB:Beta Reliable:7.5',
+      'CCC:Gamma Mismatch:6.5',
       'DDD:Delta Rookie:6',
       'EEE:Echo Inactive:6'
     ]
@@ -161,11 +205,12 @@ test('generatePrices applies ranking, smoothing, capping, inactive handling, and
   assert.equal(alphaStar.final_price, 9);
   assert.equal(alphaStar.price_change, 1);
   assert.equal(alphaStar.percentile, 100);
+  assert.equal(alphaStar.rank, 1);
 
   const alphaFringe = output.players.find((player) => player.player_id === 'alpha_fringe');
-  assert.equal(alphaFringe.reliability_factor, 0.25);
-  assert.equal(alphaFringe.adjusted_score, 22.5);
-  assert.equal(alphaFringe.final_price, 6);
+  assert.equal(alphaFringe.reliability_factor, 0.5);
+  assert.equal(alphaFringe.adjusted_score, 45);
+  assert.equal(alphaFringe.final_price, 7);
   assert.match(alphaFringe.calculation_notes.join(' '), /smoothing/i);
 
   const gammaMismatch = output.players.find((player) => player.player_id === 'gamma_mismatch');
@@ -175,7 +220,7 @@ test('generatePrices applies ranking, smoothing, capping, inactive handling, and
   const deltaRookie = output.players.find((player) => player.player_id === 'delta_rookie');
   assert.equal(deltaRookie.final_price, 6);
   assert.equal(deltaRookie.price_change, 0);
-  assert.match(deltaRookie.calculation_notes.join(' '), /No matches played; retained base price/i);
+  assert.match(deltaRookie.calculation_notes.join(' '), /Missing historical old_price/i);
 
   const echoInactive = output.players.find((player) => player.player_id === 'echo_inactive');
   assert.equal(echoInactive.percentile, 0);
@@ -222,7 +267,12 @@ test('generatePrices keeps equal adjusted scores on the same target price band',
         matches_played: 4,
         last_match_played_at_utc: '2026-04-06T18:30:00Z'
       }
-    ])
+    ], {
+      rank_price_buckets: [
+        { price: 8, slots: 2 },
+        { price: 5.5, slots: 1 }
+      ]
+    })
   );
 
   const tieA = output.players.find((player) => player.player_id === 'tie_a');
@@ -232,10 +282,10 @@ test('generatePrices keeps equal adjusted scores on the same target price band',
   assert.equal(tieA.percentile, tieB.percentile);
   assert.equal(tieA.target_price, tieB.target_price);
   assert.equal(tieA.target_price, 8);
-  assert.equal(tieC.target_price, 4);
+  assert.equal(tieC.target_price, 5.5);
 });
 
-test('generatePrices caps uncapped players at 9 credits even if their rank maps to 10', () => {
+test('generatePrices caps uncapped players at 9.5 credits even if their rank maps to 10', () => {
   const output = generatePrices(
     createJob([
       {
@@ -263,16 +313,21 @@ test('generatePrices caps uncapped players at 9 credits even if their rank maps 
         matches_played: 4,
         last_match_played_at_utc: '2026-04-06T18:30:00Z'
       }
-    ])
+    ], {
+      rank_price_buckets: [
+        { price: 10, slots: 1 },
+        { price: 9.5, slots: 1 }
+      ]
+    })
   );
 
   const sameer = output.players.find((player) => player.player_id === 'sameer_rizvi');
   assert.equal(sameer.is_uncapped, true);
-  assert.equal(sameer.target_price, 9);
-  assert.equal(sameer.smoothed_price, 9);
-  assert.equal(sameer.final_price, 9);
-  assert.equal(sameer.price_change, -1);
-  assert.match(sameer.calculation_notes.join(' '), /uncapped player price ceiling applied at 9 credits/i);
+  assert.equal(sameer.target_price, 9.5);
+  assert.equal(sameer.smoothed_price, 9.5);
+  assert.equal(sameer.final_price, 9.5);
+  assert.equal(sameer.price_change, -0.5);
+  assert.match(sameer.calculation_notes.join(' '), /uncapped player price ceiling applied at 9.5 credits/i);
 });
 
 test('generatePrices snaps recovered histories to the corrected target price', () => {
@@ -331,7 +386,7 @@ test('pricing example fixture returns stable JSON-shaped output', async () => {
   const raw = await fs.readFile(fixturePath, 'utf8');
   const output = generatePrices(JSON.parse(raw));
 
-  assert.equal(output.job_meta.engine_version, 'pricing_v1');
+  assert.equal(output.job_meta.engine_version, 'pricing_v2');
   assert.equal(output.summary.total_players_received, 4);
   assert.equal(Array.isArray(output.players), true);
   assert.equal(output.generated_at_utc, '2026-04-06T23:59:59Z');

--- a/tests/mini-fantasy-pricing-engine.test.mjs
+++ b/tests/mini-fantasy-pricing-engine.test.mjs
@@ -54,6 +54,11 @@ test('helper functions stay deterministic around averages, reliability, smoothin
   assert.equal(computeMissedFixturePenalty(1), 0);
   assert.equal(computeMissedFixturePenalty(2), 0.5);
   assert.equal(computeMissedFixturePenalty(4), 1.5);
+  assert.equal(computeMissedFixturePenalty(4, [
+    { minimum_streak: 2, penalty: 0.5 },
+    { minimum_streak: 4, penalty: 1.5 },
+    { minimum_streak: 3, penalty: 1 }
+  ]), 1.5);
   assert.equal(smoothPrice(8, 10), 9);
   assert.equal(smoothPrice(10, 9.5), 9.5);
   assert.equal(capPriceMovement(10, 8, 2, 4.5, 10), 10);


### PR DESCRIPTION
## Summary
- bring the latest Mini Fantasy pricing rebalance from dev into main
- include the PR #27 review fixes for missed-fixture penalties
- keep main-only live data and scorecard refresh work in view for merge resolution

## Notes
- dev is ahead with pricing-market changes
- main is ahead with live-data refresh, Match 39 opening override, and dot-ball replay fixes
- this PR will likely need conflict resolution in:
  - mini-fantasy/contest-engine.js
  - tests/mini-fantasy-contest-engine.test.mjs
